### PR TITLE
Resolve deprecated raye dependency

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:add_tmux
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:fix_setup_script
 
 # ** [Optional] Uncomment this section to install additional packages. **
 # ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/base/raye/install-raye-dependencies.bash
+++ b/.devcontainer/base/raye/install-raye-dependencies.bash
@@ -41,8 +41,7 @@ ${SUDO}apt-get install -y \
        wget \
 
 # Install spot
-wget -q -O - https://www.lrde.epita.fr/repo/debian.gpg | apt-key add - && \
-echo 'deb http://www.lrde.epita.fr/repo/debian/ stable/' >> /etc/apt/sources.list && \
+${SUDO}add-apt-repository ppa:asiffer/libspot && \
 ${SUDO}apt-get update && \
 ${SUDO}apt-get install -y libspot-dev && \
 # Install newer version of castxml than is available via apt-get:

--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -90,6 +90,10 @@ ARG ROS2_WORKSPACE=/workspaces/sailbot_workspace
 COPY update-bashrc.sh /sbin/update-bashrc
 RUN chmod +x /sbin/update-bashrc ; chown ros /sbin/update-bashrc ; sync ; /bin/bash -c /sbin/update-bashrc ; rm /sbin/update-bashrc
 
+# remove deprecated PPA from base:raye image
+# TODO: remove this section once base:raye is rebuilt
+RUN sed -i '$d' /etc/apt/sources.list
+
 # ROS 1 workspace setup
 WORKDIR $ROS1_WORKSPACE
 RUN mkdir src

--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -1,6 +1,10 @@
 # build using Build Dev Image workflow
 FROM ghcr.io/ubcsailbot/sailbot_workspace/base:raye as builder
 
+# remove deprecated PPA from base:raye image
+# TODO: remove this section once base:raye is rebuilt
+RUN sed -i '$d' /etc/apt/sources.list
+
 # develop configuration based on athackst's image
 # https://github.com/athackst/dockerfiles/blob/main/ros2/eloquent.Dockerfile
 ENV DEBIAN_FRONTEND=noninteractive
@@ -89,10 +93,6 @@ ARG ROS2_WORKSPACE=/workspaces/sailbot_workspace
 # bash configuration
 COPY update-bashrc.sh /sbin/update-bashrc
 RUN chmod +x /sbin/update-bashrc ; chown ros /sbin/update-bashrc ; sync ; /bin/bash -c /sbin/update-bashrc ; rm /sbin/update-bashrc
-
-# remove deprecated PPA from base:raye image
-# TODO: remove this section once base:raye is rebuilt
-RUN sed -i '$d' /etc/apt/sources.list
 
 # ROS 1 workspace setup
 WORKDIR $ROS1_WORKSPACE


### PR DESCRIPTION
The repo that we used for libspot (raye pathfinding dependency) just became deprecated. This causes `sudo apt update` to error, in turn causing our CI to fail.

What I did
- Updated the `base:raye` dockerfile to use a different repo that works
    - Since this image takes 10 hours to build, there isn't a need to update it, I didn't
- Removed the deprecated repo in the `dev` dockerfile so that `sudo apt update` is error free
   - Remove this section if `base:raye` is rebuilt