### PR TITLE
Fix x11 forwarding and revamp setup instructions

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,4 +13,4 @@
 
 1. Uncomment the section in [`.devcontainer/Dockerfile`](./Dockerfile) that installs additional packages
 2. Add the desired packages below the line `# Your package list here` with the format `<pkg1 name> <pkg2 name> ... \`
-3. Run the "Remote-Containers: Rebuild Container" command
+3. Run the "Dev Containers: Rebuild Container" command

--- a/.devcontainer/dev/README.md
+++ b/.devcontainer/dev/README.md
@@ -18,4 +18,4 @@ select "Run workflow"
 3. Update "Dev image tag" with the selected branch
 4. Click "Run workflow"
 5. Once the workflow successfully completes, ensure that the base image of [`.devcontainer/Dockerfile`](../Dockerfile)
-   uses the tag you just built, then run the "Remote-Containers: Rebuild Container" command
+   uses the tag you just built, then run the "Dev Containers: Rebuild Container" command

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 		"--volume=/tmp/.X11-unix:/tmp/.X11-unix"
 	],
 	"containerEnv": {
-		"DISPLAY": "${localEnv:MAC_DOCKER_LOCALHOST}:0",
+		"DISPLAY": "${localEnv:MAC_DOCKER_LOCALHOST}${localEnv:DISPLAY}",
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 		"--volume=/tmp/.X11-unix:/tmp/.X11-unix"
 	],
 	"containerEnv": {
-		"DISPLAY": "host.docker.internal:0",
+		"DISPLAY": "${localEnv:MAC_DOCKER_LOCALHOST}:0",
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 		"--volume=/tmp/.X11-unix:/tmp/.X11-unix"
 	],
 	"containerEnv": {
-		"DISPLAY": ":0",
+		"DISPLAY": "host.docker.internal:0",
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 	// Set *default* container specific settings.json values on container create.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This workspace can be installed on most operating systems, but it performs the b
     - [vscode](https://code.visualstudio.com/)
     - [vscode remote containers plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
     - For MacOS users, [xquartz](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088)
+        - Will also have to configure its startup
+            - `cp /opt/X11/etc/X11/xinit/xinitrc ~/.xinitrc`
+            - Add `xhost +localhost` to `~/.xinitrc` after its first line
 
 2. Clone this repository
 
@@ -46,9 +49,7 @@ This workspace can be installed on most operating systems, but it performs the b
 
 ## Run
 
-0. If you are on MacOS and want to run something with a GUI
-    1. Start XQuartz
-    2. Run `xhost +localhost` in the ***MacOS terminal***
+0. If you are on MacOS and want to run something with a GUI, start XQuartz
 
 1. Source the relevant overlay in the terminal
     - ROS 2: `srcnew`

--- a/README.md
+++ b/README.md
@@ -10,33 +10,48 @@ this workspace functions.
 
 ## Setup
 
-This workspace can be installed on most operating systems, but it performs the best on [Ubuntu](https://ubuntu.com/download/desktop).
+This workspace can be installed on most operating systems, but it performs the best out of the box on [Ubuntu](https://ubuntu.com/download/desktop).
 
 1. Install prerequisites
     - [docker](https://docs.docker.com/engine/install/)
-        - For Windows, the WSL 2 backend for Docker Desktop is recommended
+        - For Windows, use the WSL 2 backend for Docker Desktop
     - [vscode](https://code.visualstudio.com/)
-    - [vscode remote containers plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-    - For MacOS users, [xquartz](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088)
-        - Will also have to configure its startup
+        - [vscode remote development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+    - For Windows, [Ubuntu WSL distribution](https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV);
+    run the commands below in an *administrator* PowerShell window
+        - Ensure your default WSL version is 2: `wsl --set-default-version 2`
+        - Install the distribution from the Microsoft store
+        - Set the distribution as default: `wsl --set-version Ubuntu`
+        - Ensure your WSL kernel is up to date: `wsl --update`
+
+2. For Windows and MacOS, additional configuration to run GUI applications
+    - For Windows 11, GUI applications work without additional configuration,
+    *but if you upgraded from Windows 10 make sure your WSL kernel is up to date*
+    - For Windows 10, **TODO**
+    - For MacOS
+        - Follow [this guide](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) to setup xquartz
+        - Additional xquartz configuration
             - `cp /opt/X11/etc/X11/xinit/xinitrc ~/.xinitrc`
             - Add `xhost +localhost` to `~/.xinitrc` after its first line
+        - Zsh configuration
             - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` to `~/.zshrc`
             - `source ~/.zshrc`
 
-2. Clone this repository
+3. Clone this repository
 
     ```
     git clone https://github.com/UBCSailbot/sailbot_workspace.git
     ```
 
-3. Open it in VS Code
+    - For Windows, clone the repository in the WSL filesystem, for example `~/sailbot` in the Ubuntu WSL terminal
+
+4. Open it in VS Code
 
     ```
     code sailbot_workspace
     ```
 
-4. Open it in a container
+5. Open it in a container
     1. Make sure that Docker is running
     2. When you open it for the first time, you should see a little popup that asks you if you would like to open it in
        a container. Say yes!
@@ -47,21 +62,21 @@ This workspace can be installed on most operating systems, but it performs the b
        (Terminal > New Terminal), you should see that your username has been changed to `ros`, and the bottom left green
        corner should say "Dev Container"
 
-5. Import the ROS packages and install their dependencies by running the "setup" task
+6. Import the ROS packages and install their dependencies by running the "setup" task
 
 ## Run
 
-0. If you are on MacOS and want to run something with a GUI, start XQuartz
+1. If you are on MacOS and want to run something with a GUI, start XQuartz
 
-1. Source the relevant overlay in the terminal
+2. Source the relevant overlay in the terminal
     - ROS 2: `srcnew`
     - ROS 1: `srcraye`
 
-2. Build (this step might not be necessary if there are no changes made to C++ or custom msg nodes)
+3. Build (this step might not be necessary if there are no changes made to C++ or custom msg nodes)
     - ROS 2: run the "Build" VS Code task, which has the keyboard shortcut `CTRL+SHIFT+B`
     - ROS 1: `roscd` then `catkin_make`
 
-3. Run the ROS program
+4. Run the ROS program
     - ROS 2: `ros2 run ...` or `ros2 launch ...`
     - ROS 1: `rosrun ...` or `roslaunch ...`
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
 2. For Windows and MacOS, additional configuration to run GUI applications
     - For Windows 11, GUI applications work without additional configuration,
     *but if you upgraded from Windows 10 make sure your WSL kernel is up to date*
-    - For Windows 10, **TODO**
+    - For Windows 10, follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
+        - Put the first `export DISPLAY` command into `~/.bashrc`
+        - No need to run the `echo xfce4-session` command
+        - Test setup with the third option, `x11-apps`
     - For MacOS
         - Follow [this guide](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) to setup xquartz
         - Additional xquartz configuration

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This workspace can be installed on most operating systems, but it performs the b
         - Will also have to configure its startup
             - `cp /opt/X11/etc/X11/xinit/xinitrc ~/.xinitrc`
             - Add `xhost +localhost` to `~/.xinitrc` after its first line
+            - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` to `~/.zshrc`
+            - `source ~/.zshrc`
 
 2. Clone this repository
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
     - For Windows 10
         - Follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
           up to setting the `DISPLAY` variable, exclusive
-        - Add ``export DISPLAY="\`grep nameserver /etc/resolv.conf | sed 's/nameserver //'\`:0"`` to `~/.bashrc`
+        - Add ``export DISPLAY="`grep nameserver /etc/resolv.conf | sed 's/nameserver //'`:0"`` to `~/.bashrc`
           of the WSL file system
         - If VS Code is open, restart it
     - For MacOS

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
     - For Windows 10
         - Follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
           up to setting the `DISPLAY` variable, exclusive
-        - Put ``export DISPLAY="\`grep nameserver /etc/resolv.conf | sed 's/nameserver //'\`:0"`` into `~/.bashrc`
+        - Add ``export DISPLAY="\`grep nameserver /etc/resolv.conf | sed 's/nameserver //'\`:0"`` to `~/.bashrc`
           of the WSL file system
         - If VS Code is open, restart it
     - For MacOS

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This workspace can be installed on most operating systems, but it performs the b
         - Zsh configuration
             - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` to `~/.zshrc`
             - `source ~/.zshrc`
+        - If VS Code, Docker or xquartz are open, restart them
 
 3. Clone this repository
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This workspace can be installed on most operating systems, but it performs the b
         - For Windows, the WSL 2 backend for Docker Desktop is recommended
     - [vscode](https://code.visualstudio.com/)
     - [vscode remote containers plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+    - For MacOS users, [xquartz](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088)
 
 2. Clone this repository
 
@@ -44,6 +45,10 @@ This workspace can be installed on most operating systems, but it performs the b
 5. Import the ROS packages and install their dependencies by running the "setup" task
 
 ## Run
+
+0. If you are on MacOS and want to run something with a GUI
+    1. Start XQuartz
+    2. Run `xhost +localhost` in the ***MacOS terminal***
 
 1. Source the relevant overlay in the terminal
     - ROS 2: `srcnew`

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
 
 2. For Windows and MacOS, additional configuration to run GUI applications
     - For Windows 11, GUI applications work without additional configuration,
-    *but if you upgraded from Windows 10 make sure to update the WSL kernel:* `wsl --update`
+      *but if you upgraded from Windows 10 make sure to update the WSL kernel:* `wsl --update`
+      in an *administrator* PowerShell window
     - For Windows 10
         - Follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
-    up to setting the `DISPLAY` variable, exclusive
+          up to setting the `DISPLAY` variable, exclusive
         - Put ``export DISPLAY="\`grep nameserver /etc/resolv.conf | sed 's/nameserver //'\`:0"`` into `~/.bashrc`
+          of the WSL file system
         - If VS Code is open, restart it
     - For MacOS
         - Follow [this guide](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) to setup XQuartz
@@ -82,7 +84,9 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
 
 ## Run
 
-1. If you are on MacOS and want to run something with a GUI, start XQuartz
+1. For Windows 10 and MacOS, if you want to run something with a GUI
+    - For Windows 10, open the XLaunch configuration file
+    - For MacOS, start XQuartz
 
 2. Source the relevant overlay in the terminal
     - ROS 2: `srcnew`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
             - `cp /opt/X11/etc/X11/xinit/xinitrc ~/.xinitrc`
             - Add `xhost +localhost` to `~/.xinitrc` after its first line
         - Zsh configuration
-            - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` to `~/.zshrc`
+            - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` and `export DISPLAY=:0` to `~/.zshrc`
             - `source ~/.zshrc`
         - If VS Code, Docker or xquartz are open, restart them
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
        a container. Say yes!
     3. If you don't see the pop-up, click on the little green square in the bottom left corner, which should bring up
        the container dialog
-        - In the dialog, select "Remote Containers: Reopen in container"
+        - In the dialog, select "Reopen in container"
     4. VSCode will build the dockerfile inside of `.devcontainer` for you. If you open a terminal inside VSCode
        (Terminal > New Terminal), you should see that your username has been changed to `ros`, and the bottom left green
        corner should say "Dev Container"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
        (Terminal > New Terminal), you should see that your username has been changed to `ros`, and the bottom left green
        corner should say "Dev Container"
 
-6. Import the ROS packages and install their dependencies by running the "setup" task
+6. Open the workspace file `.devcontainer/config/sailbot_workspace.code-workspace` and click "Open Workspace"
+
+7. Import the ROS packages and install their dependencies by running the "setup" task
 
 ## Run
 
@@ -131,5 +133,5 @@ See [`.github/workflows/`](.github/workflows/) for the configuration files.
 
 | ROS 2 Command | ROS 1 Command | Function |
 | ------------- | ------------- | -------- |
-| `colcon_cd` | `roscd` | Navigate to ROS workspace |
 | `srcnew` | `srcraye` | Source ROS workspace overlay |
+| `colcon_cd` | `roscd` | Navigate to ROS workspace |

--- a/README.md
+++ b/README.md
@@ -14,37 +14,44 @@ This workspace can be set up on most operating systems, but it performs the best
 Ubuntu and [its derivatives](https://distrowatch.com/search.php?basedon=Ubuntu).
 
 1. Install prerequisites
-    - [docker](https://docs.docker.com/engine/install/)
-        - For Windows, use the WSL 2 backend for Docker Desktop
-        - For Ubuntu
-            - [Install Docker engine](https://docs.docker.com/engine/install/ubuntu/)
+    - For Windows, [WSL](https://learn.microsoft.com/en-us/windows/wsl/about)
+        - Run these commands in an *administrator* PowerShell window
+
+            ```
+            wsl --install --distribution Ubuntu
+            wsl --set-default Ubuntu
+            wsl --set-version Ubuntu 2
+            ```
+
+    - [Docker](https://docs.docker.com/get-started/overview/)
+        - [Install Docker](https://docs.docker.com/engine/install/)
+            - For Windows or MacOS, install Docker Desktop
+                - For Windows, use the WSL 2 backend for Docker Desktop
+            - For Linux, install Docker Engine
+        - For Linux
             - [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
             - [Configure Docker to start on boot](https://docs.docker.com/engine/install/linux-postinstall/#configure-docker-to-start-on-boot)
-    - [vscode](https://code.visualstudio.com/)
-        - [vscode remote development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
-    - For Windows, [Ubuntu WSL distribution](https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV);
-    run the commands below in an *administrator* PowerShell window
-        - Ensure your default WSL version is 2: `wsl --set-default-version 2`
-        - Install the distribution from the Microsoft store
-        - Set the distribution as default: `wsl --set-version Ubuntu`
-        - Ensure your WSL kernel is up to date: `wsl --update`
+    - [VS Code](https://code.visualstudio.com/)
+        - [Install VS Code](https://code.visualstudio.com/download)
+        - [Install VS Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
 
 2. For Windows and MacOS, additional configuration to run GUI applications
     - For Windows 11, GUI applications work without additional configuration,
-    *but if you upgraded from Windows 10 make sure your WSL kernel is up to date*
-    - For Windows 10, follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
-        - Put the first `export DISPLAY` command into `~/.bashrc`
-        - No need to run the `echo xfce4-session` command
-        - Test setup with the third option, `x11-apps`
+    *but if you upgraded from Windows 10 make sure to update the WSL kernel:* `wsl --update`
+    - For Windows 10
+        - Follow [this guide](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
+    up to setting the `DISPLAY` variable, exclusive
+        - Put ``export DISPLAY="\`grep nameserver /etc/resolv.conf | sed 's/nameserver //'\`:0"`` into `~/.bashrc`
+        - If VS Code is open, restart it
     - For MacOS
-        - Follow [this guide](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) to setup xquartz
-        - Additional xquartz configuration
+        - Follow [this guide](https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088) to setup XQuartz
+        - Additional XQuartz configuration
             - `cp /opt/X11/etc/X11/xinit/xinitrc ~/.xinitrc`
             - Add `xhost +localhost` to `~/.xinitrc` after its first line
+            - If XQuartz is open, restart it
         - Zsh configuration
             - Add `export MAC_DOCKER_LOCALHOST="docker.for.mac.host.internal"` and `export DISPLAY=:0` to `~/.zshrc`
-            - `source ~/.zshrc`
-        - If VS Code, Docker or xquartz are open, restart them
+            - If VS Code is open, restart it
 
 3. Clone this repository
 


### PR DESCRIPTION
Verify that x11 forwarding of GUI apps works for all operating systems. Can test by uncommenting the ROS tutorial dependencies, rebuilding the container, and running `ros2 run turtlesim turtlesim_node`.

I tested that it works on native Ubuntu 22.04

- [x] works on Ubuntu

I tested that it works on Windows 11 WSL 2 Ubuntu 22.04

- [x] works on Windows 11

@Harvir14 please update the README with the steps required to get it working on Windows 10

- [x] works on Windows 10

@eomielan I added some better instructions for MacOS. Please run through them and check the box below if it works

- [x] works on x86 MacOS

~~@hhenry01 try out this branch to see if it solves your X11 problems~~ it won't lol

To Do's
- [x] Need Ubuntu WSL 2, set as default distro
- [x] Clone in WSL 2
- [x] If upgrading from Windows 10, `wsl --update`
- [x] @Harvir14 Windows 10 specific stuff
- [x] @Tsuchijo Arch specific stuff
