### PR TITLE
Enable VCS cloning for regression tests

### DIFF
--- a/.github/actions/lint/run.sh
+++ b/.github/actions/lint/run.sh
@@ -2,7 +2,12 @@
 set -e
 
 source /opt/ros/${ROS2_DISTRO}/setup.bash
-./setup.sh DISABLE_VCS
+if [[ $DISABLE_VCS == "true" ]]
+then
+    ./setup.sh DISABLE_VCS
+else
+    ./setup.sh
+fi
 if [[ "$LINTER" == "clang-tidy" ]]
 then
     ./build.sh RelWithDebInfo OFF

--- a/.github/actions/test/run.sh
+++ b/.github/actions/test/run.sh
@@ -2,6 +2,11 @@
 set -e
 
 source /opt/ros/${ROS2_DISTRO}/setup.bash
-./setup.sh DISABLE_VCS
+if [[ $DISABLE_VCS == "true" ]]
+then
+    ./setup.sh DISABLE_VCS
+else
+    ./setup.sh
+fi
 ./build.sh RelWithDebInfo OFF  # Do not run static analysis or linting
 ./test.sh

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Test
         uses: ./.github/actions/test/
+        env:
+          DISABLE_VCS: false
 
   ros_lint:
     name: ament_${{ matrix.linter }}
@@ -31,6 +33,7 @@ jobs:
         uses: ./.github/actions/lint/
         env: 
           LINTER: ${{ matrix.linter }}
+          DISABLE_VCS: false
 
   # https://github.com/nosborn/github-action-markdown-cli
   markdownlint:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #67 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
The move to sub-team repo specific CI disabled the use of VCS in the CI flow. For regression tests, we want to re-enable this so that we can verify that the main branch for all sub-team repos is working.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- In intermediary commits, I changed the regression test yaml file to run on push. It worked and the final commit switched it back to weekly.
