### PR TITLE
Disable 'Move' clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: "
 
     -clang-analyzer-optin*,
     -clang-analyzer-osx*,
+    -clang-analyzer-cplusplus.Move,
     -google-objc*,
     -readability-function-cognitive-complexity,
 "


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
Disables a check in the .clang-tidy file that causes the network-systems build to fail if the ROS publish function is used.
