### PR TITLE
Fix VS Code config location and release notes template

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,44 +19,48 @@
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},
 	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.profiles.linux": {
-			"bash": {
-				"path": "bash",
-				"icon": "terminal-bash"
-			}
-		},
-		"terminal.integrated.defaultProfile.linux": "bash"
-	},
-	"extensions": [
-		// template repo
-		"althack.ament-task-provider",
-		"DotJoshJohnson.xml",
-		"ms-azuretools.vscode-docker",
-		"ms-python.python",
-		"ms-vscode.cpptools",
-		"redhat.vscode-yaml",
-		"smilerobotics.urdf",
-		"streetsidesoftware.code-spell-checker",
-		"twxs.cmake",
-		"ms-python.flake8",
-		// "yzhang.markdown-all-in-one",
-		// "zachflower.uncrustify",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.profiles.linux": {
+					"bash": {
+						"path": "bash",
+						"icon": "terminal-bash"
+					}
+				},
+				"terminal.integrated.defaultProfile.linux": "bash"
+			},
+			"extensions": [
+				// template repo
+				"althack.ament-task-provider",
+				"DotJoshJohnson.xml",
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+				"ms-vscode.cpptools",
+				"redhat.vscode-yaml",
+				"smilerobotics.urdf",
+				"streetsidesoftware.code-spell-checker",
+				"twxs.cmake",
+				"ms-python.flake8",
+				// "yzhang.markdown-all-in-one",
+				// "zachflower.uncrustify",
 
-		// UBCSailbot
-		"awesomektvn.toggle-semicolon",
-		"bierner.markdown-preview-github-styles",
-		"cschlosser.doxdocgen",
-		"DavidAnson.vscode-markdownlint",
-		"eamodio.gitlens",
-		"jeff-hykin.better-cpp-syntax",
-		"KevinRose.vsc-python-indent",
-		"llvm-vs-code-extensions.vscode-clangd",
-		"ms-vsliveshare.vsliveshare",
-		"njpwerner.autodocstring",
-		"vscode-icons-team.vscode-icons",
-		"zxh404.vscode-proto3"
-	],
+				// UBCSailbot
+				"awesomektvn.toggle-semicolon",
+				"bierner.markdown-preview-github-styles",
+				"cschlosser.doxdocgen",
+				"DavidAnson.vscode-markdownlint",
+				"eamodio.gitlens",
+				"jeff-hykin.better-cpp-syntax",
+				"KevinRose.vsc-python-indent",
+				"llvm-vs-code-extensions.vscode-clangd",
+				"ms-vsliveshare.vsliveshare",
+				"njpwerner.autodocstring",
+				"vscode-icons-team.vscode-icons",
+				"zxh404.vscode-proto3"
+			]
+		}
+	},
 	"mounts": [
 		"source=sailbot-new-project-bashhistory,target=/home/ros/commandhistory,type=volume",
 		"source=sailbot-new-project-roslog,target=/home/ros/.ros/log,type=volume"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,7 +10,7 @@ changelog:
       labels:
         - bug
 
-    - title: "Docker Changes :whale:"
+    - title: "Dev Container Configuration Changes :whale:"
       labels:
         - devcontainer
 
@@ -18,9 +18,9 @@ changelog:
       labels:
         - vscode
 
-    - title: "Workflow Changes :octocat:"
+    - title: "GitHub Configuration Changes :octocat:"
       labels:
-        - workflows
+        - github
 
     - title: "Other Changes :hammer_and_wrench:"
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,10 @@ changelog:
       - dependabot
   categories:
 
+    - title: "Bug Fixes :beetle:"
+      labels:
+        - bug
+
     - title: "Docker Changes :whale:"
       labels:
         - devcontainer
@@ -21,10 +25,6 @@ changelog:
     - title: "Other Infrastructure Changes :gear:"
       labels:
         - infrastructure
-
-    - title: "Bug Fixes :beetle:"
-      labels:
-        - bug
 
     - title: "Other Changes :hammer_and_wrench:"
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,10 +22,6 @@ changelog:
       labels:
         - workflows
 
-    - title: "Other Infrastructure Changes :gear:"
-      labels:
-        - infrastructure
-
     - title: "Other Changes :hammer_and_wrench:"
       labels:
         - "*"


### PR DESCRIPTION
- devcontainer.json format was updated since I last opened the workspace
- Move bug section to beginning because I want PR's with multiple labels including bug to go in the bug section
- Remove infra section because this whole repo is infra
- Rename workflows section to be consistent with other sections
    - `.devcontainer/` -> Dev Container Configuration Changes
    - `.github/` -> GitHub Configuration Changes
    - `.vscode/` -> VS Code Configuration Changes