### PR TITLE
Cancel in-progress runs for the current workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,10 @@ on:
     - cron: '0 1 * * 5'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   colcon-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reference: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow