### PR TITLE
Rebuild Docs on push to main

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.PATRICK_PAT }}
+          password: ${{ secrets.PAT_TOKEN }}
 
       - name: Build and push base
         uses: docker/build-push-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,4 +84,4 @@ jobs:
     - name: Dispatch Docs Publish workflow
       # https://github.com/orgs/community/discussions/26323#discussioncomment-3251448
       run: |
-        "curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PATRICK_PAT}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/UBCSailbot/docs/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'"
+        "curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/UBCSailbot/docs/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,3 +76,12 @@ jobs:
       with:
         config-file: .markdown-link-check.json
         folder-path: .
+
+  rebuild-docs:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+    - name: Dispatch Docs Publish workflow
+      # https://github.com/orgs/community/discussions/26323#discussioncomment-3251448
+      run: |
+        "curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PATRICK_PAT}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/UBCSailbot/docs/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'"

--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ This repository supports user-specific configuration files. To set this up see
 ## Run Raye's Software
 
 Raye was our previous project. Its software can be run in the [`raye` branch](https://github.com/UBCSailbot/sailbot_workspace/tree/raye).
-This branch (and Raye's codebase in general) is not in active development, so it may not have all the latest features
-in the `main` branch. The initial differences between the `main` and `raye` branch are summarized in
+The initial differences between the `main` and `raye` branches are summarized in
 [this PR](https://github.com/UBCSailbot/sailbot_workspace/pull/61).
 
 ## Documentation
 
-Further documentation, including setup instructions, can be found on [our Docs website](https://ubcsailbot.github.io/docs/current/sailbot_workspace/overview/).
+Further documentation, including setup and run instructions, can be found on [our Docs website](https://ubcsailbot.github.io/docs/current/sailbot_workspace/overview/).


### PR DESCRIPTION
Rebuild Docs on push to main, as it uses snippets of files from this repo. Also updated and renamed the token: they were generated using the ubcsailbotsoftware GitHub account

- [x] Pending UBCSailbot/docs#129
    - Merge after the docs PR to verify that this PR works: README contents should change