### PR TITLE
Use docker compose

### DIFF
--- a/.devcontainer/deployment/README.md
+++ b/.devcontainer/deployment/README.md
@@ -5,9 +5,7 @@
 ### `start_container.sh`
 
 Runs the [`base`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/.devcontainer/base-dev/base-dev.Dockerfile)
-image using the run arguments in [`devcontainer.json`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/.devcontainer/devcontainer.json).
-
-A new container is created every time this is run. The default container name is `sailbot`. Container names are unique,
+image. A new container is created every time this is run. The default container name is `sailbot`. Container names are unique,
 so if you want to use multiple deployment containers (e.g., from different branches) you will have to update the variable
 `CONTAINER_NAME` in the script.
 

--- a/.devcontainer/deployment/start_container.sh
+++ b/.devcontainer/deployment/start_container.sh
@@ -17,19 +17,10 @@ CONTAINER_NAME="sailbot"
 DOCKER_RUN_CMD="docker run -it --name $CONTAINER_NAME"
 # args to mount the repo inside the container
 DOCKER_MNT_VOL_ARGS="-v $HOST_WORKSPACE_ROOT:$CONTAINER_WORKSPACE_PATH -w $CONTAINER_WORKSPACE_PATH"
-DOCKER_RUN_CMD="$DOCKER_RUN_CMD $DOCKER_MNT_VOL_ARGS"
+# args to support can/vcan
+DOCKER_CAN_ARGS="--cap-add=NET_ADMIN --network=host"
+DOCKER_RUN_CMD="$DOCKER_RUN_CMD $DOCKER_MNT_VOL_ARGS $DOCKER_CAN_ARGS"
 
-# Parse the devcontainer.json file for docker run arguments
-get_docker_run_args()
-{
-    DOCKER_RUN_ARGS=$(sed -n '/"runArgs": \[/,/\],/p' $DEVCONTAINER_PATH) # isolate the entire runArgs field
-    DOCKER_RUN_ARGS=$(sed 's/"runArgs": \[//g' <<< "$DOCKER_RUN_ARGS")    # remove "runArgs": [
-    DOCKER_RUN_ARGS=$(sed 's/\],//g' <<< "$DOCKER_RUN_ARGS")              # remove ],
-    DOCKER_RUN_ARGS=$(sed 's/"//g' <<< "$DOCKER_RUN_ARGS")                # remove "
-    DOCKER_RUN_ARGS=$(sed 's/,//g' <<< "$DOCKER_RUN_ARGS")                # remove ,
-
-    echo $DOCKER_RUN_ARGS # return args
-}
 # Parse the Dockerfile to get the base/dev image tag
 get_dev_tag()
 {
@@ -46,9 +37,6 @@ then
     echo "docker stop $CONTAINER_NAME; docker rm $CONTAINER_NAME"
     exit 1
 fi
-
-DOCKER_RUN_ARGS=$(get_docker_run_args)
-DOCKER_RUN_CMD="$DOCKER_RUN_CMD $DOCKER_RUN_ARGS"
 
 if [[ $IMAGE_ID == "" ]]
 then

--- a/.devcontainer/deployment/start_container.sh
+++ b/.devcontainer/deployment/start_container.sh
@@ -13,7 +13,7 @@ DOCKERFILE_PATH="$DOCKERFILE_DIR/Dockerfile"
 DEVCONTAINER_PATH="$DOCKERFILE_DIR/devcontainer.json"
 CONTAINER_WORKSPACE_PATH="/workspaces/sailbot_workspace"
 # run interactive terminal and name it sailbot
-CONTAINER_NAME="sailbot"
+CONTAINER_NAME="sailbot_deployment_container"
 DOCKER_RUN_CMD="docker run -it --name $CONTAINER_NAME"
 # args to mount the repo inside the container
 DOCKER_MNT_VOL_ARGS="-v $HOST_WORKSPACE_ROOT:$CONTAINER_WORKSPACE_PATH -w $CONTAINER_WORKSPACE_PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,9 +50,5 @@
 				"zxh404.vscode-proto3"
 			]
 		}
-	},
-	"mounts": [
-		"source=sailbot-new-project-bashhistory,target=/home/ros/commandhistory,type=volume",
-		"source=sailbot-new-project-roslog,target=/home/ros/.ros/log,type=volume"
-	]
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,4 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
-// IMPORTANT: be careful with the general devcontainer.json properties
-// 		https://containers.dev/implementors/json_reference/#general-properties
-//      Do not add any properties that correspond to a docker run argument
-//		https://docs.docker.com/engine/reference/commandline/run/#options
-// 		sailbot_workspace/.devcontainer/deployment/start_container.sh parses this file for "runArgs" to run the 
-//      container, but if you use, for example, the "capAdd" JSON field then it will NOT be picked up by the script
-//      without changes
 {
 	"dockerFile": "Dockerfile",
 	"build": {
@@ -14,11 +7,8 @@
 		}
 	},
 	"remoteUser": "ros",
-	// Do not add comments to any lines within the runArgs array - it breaks the start_container.sh script
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
-		"--cap-add=NET_ADMIN",
-		"--network=host",
 		"--security-opt=seccomp:unconfined",
 		"--security-opt=apparmor:unconfined"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,10 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-	"dockerFile": "Dockerfile",
+	"name": "Sailbot Workspace",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "sailbot-workspace",
+	"workspaceFolder": "/workspaces/sailbot_workspace",
 	"remoteUser": "ros",
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt=seccomp:unconfined",
-		"--security-opt=apparmor:unconfined"
-	],
 	"containerEnv": {
 		"LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
 	"dockerFile": "Dockerfile",
-	"build": {
-		"args": {
-			"WORKSPACE": "${containerWorkspaceFolder}"
-		}
-	},
 	"remoteUser": "ros",
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspaces/sailbot_workspace:cached
+      - sailbot-new-project-bashhistory:/home/ros/commandhistory
+      - sailbot-new-project-roslog:/home/ros/.ros/log
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -18,3 +20,7 @@ services:
     security_opt:
     - seccomp:unconfined
     - apparmor:unconfined
+
+volumes:
+  sailbot-new-project-bashhistory:
+  sailbot-new-project-roslog:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,20 @@
+# adapted from https://github.com/microsoft/vscode-dev-containers/blob/main/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
+version: '3.8'
+
+services:
+  sailbot-workspace:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/sailbot_workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # From run arguments of template repository
+    cap_add:
+    - SYS_PTRACE
+    security_opt:
+    - seccomp:unconfined
+    - apparmor:unconfined


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Make the dev container use docker compose. Previously, it was built on `.devcontainer/Dockerfile`. Now it is built on `.devcontainer/docker-compose.yml`, which builds the dockerfile. Using docker compose allows the dev container to run multiple images.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Rebuild dev container locally

### Resource
- https://github.com/devcontainers/templates/tree/main/src/javascript-node-mongo
