### PR TITLE
Fix rebuild docs part 2

### DIFF
--- a/.github/workflows/test_definitions.yml
+++ b/.github/workflows/test_definitions.yml
@@ -15,6 +15,9 @@ on:
       rebuild-docs:
         required: true
         type: boolean
+    secrets:
+      gh-token:
+        required: true
 
 jobs:
   colcon-test:
@@ -126,4 +129,4 @@ jobs:
           sleep 5
           gh run watch -R UBCSailbot/docs $(gh run list -R UBCSailbot/docs -w publish.yml -L1 --json databaseId --jq '.[0].databaseId')
     env:
-      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+      GH_TOKEN: ${{ secrets.gh-token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,3 +33,16 @@ jobs:
       # Rebuilds our docs site https://ubcsailbot.github.io/docs/
       # If the docs contains a snippet of a file in this repository, set to true
       rebuild-docs: true
+
+  # Rebuilds our docs site https://ubcsailbot.github.io/docs/
+  rebuild-docs-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dispatch Docs Publish workflow
+      # https://github.com/orgs/community/discussions/26323#discussioncomment-5600001
+      run: |
+          gh workflow run publish.yml -R UBCSailbot/docs
+          sleep 5
+          gh run watch -R UBCSailbot/docs $(gh run list -R UBCSailbot/docs -w publish.yml -L1 --json databaseId --jq '.[0].databaseId')
+    env:
+      GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,16 +33,6 @@ jobs:
       # Rebuilds our docs site https://ubcsailbot.github.io/docs/
       # If the docs contains a snippet of a file in this repository, set to true
       rebuild-docs: true
-
-  # Rebuilds our docs site https://ubcsailbot.github.io/docs/
-  rebuild-docs-test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Dispatch Docs Publish workflow
-      # https://github.com/orgs/community/discussions/26323#discussioncomment-5600001
-      run: |
-          gh workflow run publish.yml -R UBCSailbot/docs
-          sleep 5
-          gh run watch -R UBCSailbot/docs $(gh run list -R UBCSailbot/docs -w publish.yml -L1 --json databaseId --jq '.[0].databaseId')
-    env:
-      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
+    secrets:
+      gh-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
   test-definitions:
     # Runs another workflow, refer to
     # https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
-    uses: UBCSailbot/sailbot_workspace/.github/workflows/test_definitions.yml@main
+    uses: UBCSailbot/sailbot_workspace/.github/workflows/test_definitions.yml@user/patrick-5546/fix-rebuild-docs2
     with:
       repository: ${{ github.event.repository.name }}
       # VCS is used to clone all subteam repositories, so set to


### PR DESCRIPTION
Follow up of #122.

Could not detect `GH_TOKEN` environment variable: https://github.com/UBCSailbot/sailbot_workspace/actions/runs/5073248488/jobs/9112013165. This is because secrets are not passed to the reusable workflow.

Once this PR is merged in, will need to update caller workflows:
- [ ] Sailbot workspace; change branch to `main`
- [ ] Network systems: add `gh-token` secret