### PR TITLE
Add template repo run arguments to deployment container

### DIFF
--- a/.devcontainer/deployment/start_container.sh
+++ b/.devcontainer/deployment/start_container.sh
@@ -17,9 +17,10 @@ CONTAINER_NAME="sailbot_deployment_container"
 DOCKER_RUN_CMD="docker run -it --name $CONTAINER_NAME"
 # args to mount the repo inside the container
 DOCKER_MNT_VOL_ARGS="-v $HOST_WORKSPACE_ROOT:$CONTAINER_WORKSPACE_PATH -w $CONTAINER_WORKSPACE_PATH"
+DOCKER_TEMPATE_REPO_ARGS="--cap-add=SYS_PTRACE --security-opt=seccomp:unconfined --security-opt=apparmor:unconfined"
 # args to support can/vcan
 DOCKER_CAN_ARGS="--cap-add=NET_ADMIN --network=host"
-DOCKER_RUN_CMD="$DOCKER_RUN_CMD $DOCKER_MNT_VOL_ARGS $DOCKER_CAN_ARGS"
+DOCKER_RUN_CMD="$DOCKER_RUN_CMD $DOCKER_MNT_VOL_ARGS $DOCKER_TEMPATE_REPO_ARGS $DOCKER_CAN_ARGS"
 
 # Parse the Dockerfile to get the base/dev image tag
 get_dev_tag()


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Deployment container should have all the same run arguments as the dev container. Previously we were missing the ones from the template repository, https://github.com/athackst/vscode_ros2_workspace:

https://github.com/UBCSailbot/sailbot_workspace/blob/ac897795ceed0381c6f484a90d233eb3040729fd/.devcontainer/docker-compose.yml#L18-L23

@hhenry01 FYI

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] `./start_container.sh` successfully starts deployment container 
