### PR TITLE
Source ROS underlay if overlay not found

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:fix-ros-sourcing
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:fix-ros-sourcing3
 
 # Copy configuration files (e.g., .vimrc) from config/ to the container's home directory
 ARG USERNAME=ros

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:setup-local-pathfinding3
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:fix-ros-sourcing
 
 # Copy configuration files (e.g., .vimrc) from config/ to the container's home directory
 ARG USERNAME=ros

--- a/.devcontainer/base-dev/update-bashrc.sh
+++ b/.devcontainer/base-dev/update-bashrc.sh
@@ -15,6 +15,6 @@ echo "if [ -f $ROS_WORKSPACE/install/setup.bash ]" >> $HOME/.bashrc
 echo "then" >> $HOME/.bashrc
 echo "    source $ROS_WORKSPACE/install/setup.bash" >> $HOME/.bashrc
 echo "else" >> $HOME/.bashrc
-echo "    echo \"WARNING: Can't source the ROS workspace overlay: build then run `source ~/.bashrc`\"" >> $HOME/.bashrc
+echo "    echo \"WARNING: Can't find the ROS workspace overlay: build then open a new terminal\"" >> $HOME/.bashrc
 echo "    source /opt/ros/$ROS_DISTRO/setup.bash" >> $HOME/.bashrc
 echo "fi" >> $HOME/.bashrc

--- a/.devcontainer/base-dev/update-bashrc.sh
+++ b/.devcontainer/base-dev/update-bashrc.sh
@@ -15,6 +15,6 @@ echo "if [ -f $ROS_WORKSPACE/install/setup.bash ]" >> $HOME/.bashrc
 echo "then" >> $HOME/.bashrc
 echo "    source $ROS_WORKSPACE/install/setup.bash" >> $HOME/.bashrc
 echo "else" >> $HOME/.bashrc
-echo "    echo \"WARNING: Can't find the ROS workspace overlay: build then open a new terminal\"" >> $HOME/.bashrc
+echo "    echo \"WARNING: Can't find the ROS workspace overlay: build then run 'source ~/.bashrc`\"" >> $HOME/.bashrc
 echo "    source /opt/ros/$ROS_DISTRO/setup.bash" >> $HOME/.bashrc
 echo "fi" >> $HOME/.bashrc

--- a/.devcontainer/base-dev/update-bashrc.sh
+++ b/.devcontainer/base-dev/update-bashrc.sh
@@ -15,6 +15,6 @@ echo "if [ -f $ROS_WORKSPACE/install/setup.bash ]" >> $HOME/.bashrc
 echo "then" >> $HOME/.bashrc
 echo "    source $ROS_WORKSPACE/install/setup.bash" >> $HOME/.bashrc
 echo "else" >> $HOME/.bashrc
-echo "    echo \"WARNING: Can't find the ROS workspace overlay: build then run 'source ~/.bashrc`\"" >> $HOME/.bashrc
+echo "    echo \"WARNING: Can't find the ROS workspace overlay: build then run 'source ~/.bashrc'\"" >> $HOME/.bashrc
 echo "    source /opt/ros/$ROS_DISTRO/setup.bash" >> $HOME/.bashrc
 echo "fi" >> $HOME/.bashrc

--- a/.devcontainer/base-dev/update-bashrc.sh
+++ b/.devcontainer/base-dev/update-bashrc.sh
@@ -16,4 +16,5 @@ echo "then" >> $HOME/.bashrc
 echo "    source $ROS_WORKSPACE/install/setup.bash" >> $HOME/.bashrc
 echo "else" >> $HOME/.bashrc
 echo "    echo \"WARNING: Can't source the ROS workspace overlay: build then run `source ~/.bashrc`\"" >> $HOME/.bashrc
+echo "    source /opt/ros/$ROS_DISTRO/setup.bash" >> $HOME/.bashrc
 echo "fi" >> $HOME/.bashrc


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Thanks to @Krithik1 for finding this bug

When building from scratch in a fresh dev container would get this error:
![image](https://github.com/UBCSailbot/sailbot_workspace/assets/65756895/a7863e65-0c3f-40f4-9592-1a9bc82cc50a)

To resolve this we have to source ROS in all cases. The ROS overlay is only available after building, so if the overlay doesn't exist we should source the underlay.