### PR TITLE
Fix VCS enabled in other repositories

### DIFF
--- a/.github/workflows/test_definitions.yml
+++ b/.github/workflows/test_definitions.yml
@@ -48,14 +48,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -65,7 +65,7 @@ jobs:
     - name: Test
       uses: ./.github/actions/test/
       env:
-        DISABLE_VCS: ${{ inputs.repository != github.event.repository.name }}
+        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
 
   ament-lint:
     strategy:
@@ -83,14 +83,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -101,7 +101,7 @@ jobs:
       uses: ./.github/actions/ament-lint/
       env:
         LINTER: ${{ matrix.linter }}
-        DISABLE_VCS: ${{ inputs.repository != github.event.repository.name }}
+        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
 
   clang-tidy:
     runs-on: ubuntu-latest
@@ -113,14 +113,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != github.event.repository.name }}
+      if: ${{ inputs.repository != sailbot_workspace }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -130,7 +130,7 @@ jobs:
     - name: Run linter
       uses: ./.github/actions/clang-tidy/
       env:
-        DISABLE_VCS: ${{ inputs.repository != github.event.repository.name }}
+        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
 
   # https://github.com/nosborn/github-action-markdown-cli
   markdownlint:

--- a/.github/workflows/test_definitions.yml
+++ b/.github/workflows/test_definitions.yml
@@ -48,14 +48,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -65,7 +65,7 @@ jobs:
     - name: Test
       uses: ./.github/actions/test/
       env:
-        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
+        DISABLE_VCS: ${{ inputs.repository != 'sailbot_workspace' }}
 
   ament-lint:
     strategy:
@@ -83,14 +83,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -101,7 +101,7 @@ jobs:
       uses: ./.github/actions/ament-lint/
       env:
         LINTER: ${{ matrix.linter }}
-        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
+        DISABLE_VCS: ${{ inputs.repository != 'sailbot_workspace' }}
 
   clang-tidy:
     runs-on: ubuntu-latest
@@ -113,14 +113,14 @@ jobs:
           repository: UBCSailbot/sailbot_workspace
 
     - name: Checkout ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/${{ inputs.repository }}
           path: src/${{ inputs.repository }}
 
     - name: Checkout custom_interfaces ROS package
-      if: ${{ inputs.repository != sailbot_workspace }}
+      if: ${{ inputs.repository != 'sailbot_workspace' }}
       uses: actions/checkout@v3
       with:
           repository: UBCSailbot/custom_interfaces
@@ -130,7 +130,7 @@ jobs:
     - name: Run linter
       uses: ./.github/actions/clang-tidy/
       env:
-        DISABLE_VCS: ${{ inputs.repository != sailbot_workspace }}
+        DISABLE_VCS: ${{ inputs.repository != 'sailbot_workspace' }}
 
   # https://github.com/nosborn/github-action-markdown-cli
   markdownlint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     # see https://github.com/UBCSailbot/sailbot_workspace/blob/main/.github/workflows/test_definitions.yml
     # for documentation on the inputs and secrets below
     with:
-      repository: ${{ github.event.repository.name }}
+      repository: local_pathfinding
       ros-ci: true
       clang-tidy: true
       rebuild-docs: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     # see https://github.com/UBCSailbot/sailbot_workspace/blob/main/.github/workflows/test_definitions.yml
     # for documentation on the inputs and secrets below
     with:
-      repository: local_pathfinding
+      repository: ${{ github.event.repository.name }}
       ros-ci: true
       clang-tidy: true
       rebuild-docs: true


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
In other repositories, VCS should be disabled. However, VCS seems to be running in `colcon-test`, `ament-lint`, and `clang-tidy`: https://github.com/UBCSailbot/local_pathfinding/actions/runs/5365212299

This is due to the fact that `github.event.repository.name` evaluates to the caller workflow's repository, not the reusable workflow's.