### PR TITLE
Revert setup skipping existing repositories

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ function warn() {
 # Import all project repositories
 if [[ $DISABLE_VCS != "true" ]]; then
     echo "Importing project repositories..."
-    vcs import < src/new_project.repos src --skip-existing
+    vcs import < src/new_project.repos src
 else
     warn "VCS disabled. Skipping project repository imports..."
 fi


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
I think that it is desirable for the setup task to try to switch to the branches in new_project.repos. It will error out if there are conflicts. The setup task should only be run when you first setup the workspace or want to switch to the default branches.
