### PR TITLE
Fix base/dev image long build times

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:mongodb-cpp
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:refactor-images-v2
 
 # Copy configuration files (e.g., .vimrc) from config/ to the container's home directory
 ARG USERNAME=ros

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -70,21 +70,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         mongodb-database-tools \
         mongodb-mongosh \
-        libmongoc-dev \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-ENV DEBIAN_FRONTEND=
-
-# setup MongoDB C++ Packages
-ENV DEBIAN_FRONTEND=noninteractive
-# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
-RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
-    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
-    && cd mongo-cxx-driver-r3.6.7/build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && cmake --build . \
-    && cmake --build . --target  install
 ENV DEBIAN_FRONTEND=
 
 FROM local-base as ros-dev

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f as base
+FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367-v2 as base
 
 # install base apt dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367 as base
+FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367-v2 as base
 
 # install base apt dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367-v2 as base
+FROM ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367 as base
 
 # install base apt dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/pre-base/build-pre-base.sh
+++ b/.devcontainer/pre-base/build-pre-base.sh
@@ -2,6 +2,6 @@
 
 docker buildx build . \
     --file pre-base.Dockerfile \
-    --tag ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f \
+    --tag ghcr.io/ubcsailbot/sailbot_workspace/pre-base:ros_humble-ompl_4c86b2f-mongo_367-v2 \
     --platform linux/arm64,linux/amd64 \
     --push

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -110,27 +110,6 @@ RUN cmake \
     && ninja -j `nproc` \
     && ninja install
 
-FROM fix-certificates AS mongo-cxx-driver-builder
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libmongoc-dev \
-        wget \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-# setup MongoDB C++ Packages
-# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
-RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
-    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
-    && cd mongo-cxx-driver-r3.6.7/build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && cmake --build . \
-    && cmake --build . --target  install
-ENV DEBIAN_FRONTEND=
-
 FROM ros-pre-base as pre-base
 LABEL org.opencontainers.image.source = "https://github.com/UBCSailbot/sailbot_workspace"
 
@@ -159,7 +138,15 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# setup MongoDB C++ Packages
+# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
+RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
+    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
+    && cd mongo-cxx-driver-r3.6.7/build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build . \
+    && cmake --build . --target  install
 ENV DEBIAN_FRONTEND=
 
 COPY --from=ompl-builder /usr /usr
-COPY --from=mongo-cxx-driver-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:22.04 AS ompl-source
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -110,6 +110,30 @@ RUN cmake \
     && ninja -j `nproc` \
     && ninja install
 
+FROM fix-certificates AS mongo-cxx-driver-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        libmongoc-dev \
+        wget \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# setup MongoDB C++ Packages
+# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
+RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
+    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
+    && cd mongo-cxx-driver-r3.6.7/build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build . \
+    && cmake --build . --target  install
+ENV DEBIAN_FRONTEND=
+
 FROM ros-pre-base as pre-base
 LABEL org.opencontainers.image.source = "https://github.com/UBCSailbot/sailbot_workspace"
 
@@ -118,7 +142,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
-        git \
         libboost-filesystem-dev \
         libboost-numpy-dev \
         libboost-program-options-dev \
@@ -139,15 +162,7 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-# setup MongoDB C++ Packages
-# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
-RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
-    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
-    && cd mongo-cxx-driver-r3.6.7/build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && cmake --build . \
-    && cmake --build . --target  install
 ENV DEBIAN_FRONTEND=
 
 COPY --from=ompl-builder /usr /usr
+COPY --from=mongo-cxx-driver-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -115,6 +115,7 @@ RUN apt-get update \
         libboost-system-dev \
         libeigen3-dev \
         libflann-dev \
+        libmongoc-dev \
         libode-dev \
         libtriangle-dev \
         ninja-build \
@@ -126,6 +127,17 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+ENV DEBIAN_FRONTEND=
+
+# setup MongoDB C++ Packages
+ENV DEBIAN_FRONTEND=noninteractive
+# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
+RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
+    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
+    && cd mongo-cxx-driver-r3.6.7/build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build . \
+    && cmake --build . --target  install
 ENV DEBIAN_FRONTEND=
 
 COPY --from=ompl-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -118,6 +118,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
+        git \
         libboost-filesystem-dev \
         libboost-numpy-dev \
         libboost-program-options-dev \

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -161,3 +161,4 @@ RUN apt-get update \
 ENV DEBIAN_FRONTEND=
 
 COPY --from=ompl-builder /usr /usr
+COPY --from=mongo-cxx-driver-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -1,10 +1,19 @@
-FROM ubuntu:22.04 AS ompl-source
+FROM ubuntu:22.04 AS fix-certificates
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        git \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+ENV DEBIAN_FRONTEND=
+
+FROM fix-certificates AS ompl-source
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -13,7 +22,7 @@ WORKDIR /ompl
 RUN git reset --hard 4c86b2f
 
 # From https://github.com/athackst/dockerfiles/blob/32a872348af0ad25ec4a6e6184cb803357acb6ab/ros2/humble.Dockerfile
-FROM ubuntu:22.04 AS ros-pre-base
+FROM fix-certificates AS ros-pre-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -35,7 +44,6 @@ RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
 
 # Install ROS2
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
         curl \
         gnupg2 \
         lsb-release \

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -35,6 +35,7 @@ RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
 
 # Install ROS2
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
         curl \
         gnupg2 \
         lsb-release \

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -66,7 +66,7 @@ ENV ROS_VERSION=2
 ENV DEBIAN_FRONTEND=
 
 # Based on https://github.com/ompl/ompl/blob/4c86b2fecf7084ae9073bf6a837176d0be169721/scripts/docker/ompl.Dockerfile
-FROM ros-pre-base AS ompl-builder
+FROM fix-certificates AS ompl-builder
 # avoid interactive configuration dialog from tzdata, which gets pulled in
 # as a dependency
 ENV DEBIAN_FRONTEND=noninteractive
@@ -110,6 +110,27 @@ RUN cmake \
     && ninja -j `nproc` \
     && ninja install
 
+FROM fix-certificates AS mongo-cxx-driver-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libmongoc-dev \
+        wget \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# setup MongoDB C++ Packages
+# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
+RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
+    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
+    && cd mongo-cxx-driver-r3.6.7/build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build . \
+    && cmake --build . --target  install
+ENV DEBIAN_FRONTEND=
+
 FROM ros-pre-base as pre-base
 LABEL org.opencontainers.image.source = "https://github.com/UBCSailbot/sailbot_workspace"
 
@@ -126,7 +147,6 @@ RUN apt-get update \
         libboost-system-dev \
         libeigen3-dev \
         libflann-dev \
-        libmongoc-dev \
         libode-dev \
         libtriangle-dev \
         ninja-build \
@@ -138,17 +158,6 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-ENV DEBIAN_FRONTEND=
-
-# setup MongoDB C++ Packages
-ENV DEBIAN_FRONTEND=noninteractive
-# mongo-cxx-driver version must match libmongoc-dev version - see https://mongocxx.org/mongocxx-v3/installation/linux/
-RUN wget https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.6.7/mongo-cxx-driver-r3.6.7.tar.gz \
-    && tar -xzf mongo-cxx-driver-r3.6.7.tar.gz \
-    && cd mongo-cxx-driver-r3.6.7/build \
-    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && cmake --build . \
-    && cmake --build . --target  install
 ENV DEBIAN_FRONTEND=
 
 COPY --from=ompl-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -164,5 +164,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 ENV DEBIAN_FRONTEND=
 
-COPY --from=mongo-cxx-driver-builder /usr /usr
 COPY --from=ompl-builder /usr /usr
+COPY --from=mongo-cxx-driver-builder /usr/local /usr/local

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -164,5 +164,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 ENV DEBIAN_FRONTEND=
 
-COPY --from=ompl-builder /usr /usr
 COPY --from=mongo-cxx-driver-builder /usr /usr
+COPY --from=ompl-builder /usr /usr

--- a/.devcontainer/pre-base/pre-base.Dockerfile
+++ b/.devcontainer/pre-base/pre-base.Dockerfile
@@ -147,6 +147,7 @@ RUN apt-get update \
         libboost-system-dev \
         libeigen3-dev \
         libflann-dev \
+        libmongoc-dev \
         libode-dev \
         libtriangle-dev \
         ninja-build \


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- Since #161, base/dev image build times went from 17 min to 2 hrs+
- The cause of this was building `mongo-cxx-driver` from source
- Since this is needed for everything, moved to the pre-base image
- Effect: base/dev image build times are back to 17 min, and reduced their size by 100mb
