### PR TITLE
Don't cancel in-progress jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Cancel in-progress runs for the current workflow
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   # CI for all UBCSailbot repositories defined in one place
   # Runs another workflow: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow


### PR DESCRIPTION
Workflows may be triggered from this repository or others. We don't want these runs to cancel each other, and instead want all runs to complete