### PR TITLE
Start and kill virtual iridium in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -e
 
+function signal_handler() {
+    if [ -n "$(pgrep -f virtual_iridium)" ]; then
+        pkill -f virtual_iridium
+    fi
+}
+
+# Test failures terminate the script
+# Catch the signal so child processes can be cleaned up
+trap 'exit' INT TERM
+trap 'signal_handler' EXIT
+
 if [ -f install/local_setup.bash ]; then source install/local_setup.bash; fi
+if [ -d src/network_systems ]; then src/network_systems/scripts/run_virtual_iridium.sh &> /dev/null & fi
 colcon test --packages-ignore virtual_iridium --merge-install --event-handlers console_cohesion+
 colcon test-result
+exit 0


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- New dependency of NET tests: https://github.com/UBCSailbot/network_systems/pull/52

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Exit code of 0 is returned when all tests pass
    - Tested in https://github.com/UBCSailbot/local_pathfinding/pull/47
- Exit code of 1 is returned when a test fails
- Correct exit code is returned when network_systems is not present (virtual_iridium is never run in this case)
