### PR TITLE
Add rapidyaml as a static library

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:add-ament-mypy-v2
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:rapidyaml
 
 # Copy configuration files (e.g., .vimrc) from config/ to the container's home directory
 ARG USERNAME=ros

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:rapidyaml
+FROM ghcr.io/ubcsailbot/sailbot_workspace/dev:rapid
 
 # Copy configuration files (e.g., .vimrc) from config/ to the container's home directory
 ARG USERNAME=ros

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -175,9 +175,9 @@ ENV DEBIAN_FRONTEND=
 
 # install rapidyaml for diagnostics
 ENV DEBIAN_FRONTEND=noninteractive
-RUN wget https://github.com/biojppm/rapidyaml/releases/download/v0.5.0/rapidyaml-0.5.0-ubuntu-20.04.deb && \
-    apt-get install ./rapidyaml-0.5.0-ubuntu-20.04.deb && \
-    rm -f rapidyaml-0.5.0-ubuntu-20.04.deb
+RUN wget https://github.com/biojppm/rapidyaml/releases/download/v0.5.0/rapidyaml-0.5.0-ubuntu-20.04.deb
+RUN apt-get install ./rapidyaml-0.5.0-ubuntu-20.04.deb
+RUN rm -f rapidyaml-0.5.0-ubuntu-20.04.deb
 ENV DEBIAN_FRONTEND=
 
 # install other helpful apt packages

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -173,6 +173,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 ENV DEBIAN_FRONTEND=
 
+# install rapidyaml for diagnostics
+ENV DEBIAN_FRONTEND=noninteractive
+RUN wget https://github.com/biojppm/rapidyaml/releases/download/v0.5.0/rapidyaml-0.5.0-ubuntu-20.04.deb && \
+    apt-get install ./rapidyaml-0.5.0-ubuntu-20.04.deb && \
+    rm -f rapidyaml-0.5.0-ubuntu-20.04.deb
+ENV DEBIAN_FRONTEND=
+
 # install other helpful apt packages
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/.devcontainer/base-dev/base-dev.Dockerfile
+++ b/.devcontainer/base-dev/base-dev.Dockerfile
@@ -175,9 +175,13 @@ ENV DEBIAN_FRONTEND=
 
 # install rapidyaml for diagnostics
 ENV DEBIAN_FRONTEND=noninteractive
-RUN wget https://github.com/biojppm/rapidyaml/releases/download/v0.5.0/rapidyaml-0.5.0-ubuntu-20.04.deb
-RUN apt-get install ./rapidyaml-0.5.0-ubuntu-20.04.deb
-RUN rm -f rapidyaml-0.5.0-ubuntu-20.04.deb
+RUN wget https://github.com/biojppm/rapidyaml/releases/download/v0.5.0/rapidyaml-0.5.0-src.tgz
+RUN tar -xzf rapidyaml-0.5.0-src.tgz && \
+    cd rapidyaml-0.5.0-src && \
+    cmake -S "." -B ./build/Release/ryml-build "-DCMAKE_INSTALL_PREFIX=/usr" -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build ./build/Release/ryml-build --parallel --config Release && \
+    cmake --build ./build/Release/ryml-build --config Release --target install && \
+    rm -rf *rapidyaml*
 ENV DEBIAN_FRONTEND=
 
 # install other helpful apt packages


### PR DESCRIPTION
This PR adds rapidyaml as a static library for use in the diagnostics app. 

Link to rapidyaml: https://github.com/biojppm/rapidyaml.git