### PR TITLE
CI fails if called workflow fails

### DIFF
--- a/.github/workflows/test_definitions.yml
+++ b/.github/workflows/test_definitions.yml
@@ -167,7 +167,7 @@ jobs:
       run: |
           gh workflow run tests.yml -R UBCSailbot/docs
           sleep 5
-          gh run watch -R UBCSailbot/docs $(gh run list -R UBCSailbot/docs -w tests.yml -L1 --json databaseId --jq '.[0].databaseId')
+          gh run watch --exit-status -R UBCSailbot/docs $(gh run list -R UBCSailbot/docs -w tests.yml -L1 --json databaseId --jq '.[0].databaseId')
     env:
       GH_TOKEN: ${{ secrets.gh-token }}
 
@@ -181,6 +181,6 @@ jobs:
       run: |
           gh workflow run tests.yml -R UBCSailbot/sailbot_workspace
           sleep 5
-          gh run watch -R UBCSailbot/sailbot_workspace $(gh run list -R UBCSailbot/sailbot_workspace -w tests.yml -L1 --json databaseId --jq '.[0].databaseId')
+          gh run watch --exit-status -R UBCSailbot/sailbot_workspace $(gh run list -R UBCSailbot/sailbot_workspace -w tests.yml -L1 --json databaseId --jq '.[0].databaseId')
     env:
       GH_TOKEN: ${{ secrets.gh-token }}


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- The jobs `rebuild-docs` and `run-sailbot-workspace-ci` run workflows in other repositories
- I noticed that if these workflows fail, the jobs still pass
- Fixed this bug by adding `--exit-status` argument to `gh run watch`

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- https://cli.github.com/manual/gh_run_watch
