### PR TITLE
Remove clang-tidy Infinite Loop Check to Reduce Runtime

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: "
     readability*,
 
     -bugprone-easily-swappable-parameters,
+    -bugprone-infinite-loop,
     -clang-analyzer-optin*,
     -clang-analyzer-osx*,
     -clang-analyzer-cplusplus.Move,


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
Disable the `bugprone-infinite-loop` check for clang-tidy. This check turned out to be extremely slow for iterable data structures, even when there was no loop in network_systems code.

Isolated the specific check using the command: `clang-tidy -p build/  src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp --enable-check-profile`

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [ ] 

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- https://clang.llvm.org/extra/clang-tidy/checks/bugprone/infinite-loop.html
