### PR TITLE
Support multiple global launch configs

### DIFF
--- a/src/global_launch/main_launch.py
+++ b/src/global_launch/main_launch.py
@@ -22,10 +22,11 @@ DEVELOPMENT_ROS_PACKAGES = ["controller", "boat_simulator", "local_pathfinding",
 ROS_PACKAGES_DIR = os.path.join(
     os.getenv("ROS_WORKSPACE", default="/workspaces/sailbot_workspace"), "src"
 )
+GLOBAL_LAUNCH_CONFIG = os.path.join(ROS_PACKAGES_DIR, "global_launch", "config", "globals.yaml")
 GLOBAL_LAUNCH_ARGUMENTS = [
     DeclareLaunchArgument(
         name="config",
-        default_value=os.path.join(ROS_PACKAGES_DIR, "global_launch", "config", "globals.yaml"),
+        default_value=GLOBAL_LAUNCH_CONFIG,
         description="Path to ROS parameter config file. Controls ROS parameters passed into"
         + " ROS nodes",
     ),


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #215 
Allows us to specify multiple `.yaml` files when doing `ros2 launch`. What this does is allow us to specify a base configuration and allow for overriding of specific nodes. For example, if we do `ros2 launch network_systems main_launch.py config:=config1.yaml,config2.yaml`, then:
1. globals.yaml is loaded and processed
2. config1.yaml is loaded and overrides any duplicate parameters with globals.yaml
3. config2.yaml is loaded and override previous duplicate parameters
Non-duplicate parameters are unchanged.

To take advantage of this overriding structure, main_launch.py in subteam repos should be updated such that:
- inside `get_global_launch_arguments()` assign a global variable `global_launch_config = module.GLOBAL_LAUNCH_CONFIG`
- In each `get_x_description()`, assign `ros_parameters = [global_launch_config, *LaunchConfiguration("config").perform(context).split(","), <whatever else>]`
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Tested with this network_systems PR: https://github.com/UBCSailbot/network_systems/pull/80

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- 
