### PR TITLE
Run extract-metadata job when needed

### DIFF
--- a/.github/workflows/test_definitions.yml
+++ b/.github/workflows/test_definitions.yml
@@ -46,7 +46,7 @@ jobs:
   extract-metadata:
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: inputs.ros-ci || inputs.clang-tidy
+    if: inputs.ros-ci || inputs.clang-tidy || inputs.markdown-ci
     permissions:
       actions: read
     outputs:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- In #218 the extract-metadata job is run for the markdown linter jobs. This PR fixes a bug where extract-metadata didn't run when only markdown linters where run (not ROS linters or clang tidy)
