### PR TITLE
Addition of Global Parameters for Mock Global Path Node

### DIFF
--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -32,7 +32,7 @@ ROS parameters common across all ROS nodes in the network.
 
 ROS parameters specific to the nodes in the local_pathfinding package.
 
-### `node_mock_global_path`
+### `mgp_main`
 
 **`global_path_filepath`**
 

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -28,6 +28,24 @@ ROS parameters common across all ROS nodes in the network.
 - _Datatype_: `double`
 - _Range_: `(0.0, MAX_DOUBLE)`
 
+## Local Pathfinding Parameters
+
+ROS parameters specific to the nodes in the local_pathfinding package.
+
+### `node_mock_global_path`
+
+**`global_path_filepath`**
+
+- _Description_: The absolute filepath to a global path csv file.
+- _Datatype_: `string`
+- _Acceptable Values_: Any valid filepath to a properly formatted csv file.
+
+**`interval_spacing`**
+
+- _Description_: The upper bound on spacing between each point in the global path in km.
+- _Datatype_: `double`
+- _Range_: `(0.0, MAX_DOUBLE)`
+
 ## Boat Simulator Parameters
 
 ROS parameters specific to the nodes in the boat simulator.

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -43,7 +43,7 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 **`interval_spacing`**
 
 - _Description_: The upper bound on spacing between each point in the global path in km.
-- _Datatype_: `double`
+- _Datatype_: `float`
 - _Range_: `(0.0, MAX_DOUBLE)`
 
 ## Boat Simulator Parameters

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -1,9 +1,11 @@
+# global parameters
 /**:
    ros__parameters:
       # Publishers' period (seconds): how often the publishers publish
       pub_period_sec: 0.5
-# mock_global_path parameters
-node_mock_global_path:
+
+# local_pathfinding parameters
+mgp_main:
    ros__parameters:
       global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
       interval_spacing: 30.0

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -2,6 +2,11 @@
    ros__parameters:
       # Publishers' period (seconds): how often the publishers publish
       pub_period_sec: 0.5
+# mock_global_path parameters
+node_mock_global_path:
+   ros__parameters:
+      global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
+      interval_spacing: 30.0
 
 # boat_simulator parameters
 low_level_control_node:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
Linked to Issue [49](https://github.com/UBCSailbot/local_pathfinding/issues/49) in Local Pathfinding.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->

The purpose was to set some parameters, for the mock global path node, in the global params file rather than in the node's python file.

The added parameters are:

1. global_path_filepath
2. interval_spacing

### Verification
1. Run the global or local pathfinding launch file with development mode (default)
    ```
    ros2 launch local_pathfinding main_launch.py
    ```
2. In a different terminal run some ros2 param commands
    ```
    ros2 param get /mgp_main global_path_filepath
    ros2 param set /mgp_main global_path_filepath /workspaces/sailbot_workspace/src/local_pathfinding/global_paths/path_2.csv
    ```

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- [Link](https://github.com/UBCSailbot/local_pathfinding/pull/61) to the PR for this issue.