### PR TITLE
Added a write parameter for the Mock Global Path node

### DIFF
--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -43,7 +43,7 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 **`interval_spacing`**
 
 - _Description_: The upper bound on spacing between each point in the global path in km.
-- _Datatype_: `float`
+- _Datatype_: `double`
 - _Range_: `(0.0, MAX_DOUBLE)`
 
 **`write`**

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -52,6 +52,12 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 - _Datatype_: `boolean`
 - _Acceptable Values_: `true`, `false`
 
+**`gps_threshold`**
+
+- _Description_: A new path will be generated if the GPS position changed by more than this amount in km.
+- _Datatype_: `double`
+- _Acceptable Values_: `(0.0, MAX_DOUBLE)`
+
 ## Boat Simulator Parameters
 
 ROS parameters specific to the nodes in the boat simulator.

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -58,6 +58,12 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 - _Datatype_: `double`
 - _Acceptable Values_: `(0.0, MAX_DOUBLE)`
 
+**`force`**
+
+- _Description_: Force the mock global path callback to update the global path when set to true.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
 ## Boat Simulator Parameters
 
 ROS parameters specific to the nodes in the boat simulator.

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -54,9 +54,9 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 
 **`gps_threshold`**
 
-- _Description_: A new path will be generated if the GPS position changed by more than this amount in km.
+- _Description_: A new path will be generated if the GPS position changed by more thangps_threshold*interval_spacing.
 - _Datatype_: `double`
-- _Acceptable Values_: `(0.0, MAX_DOUBLE)`
+- _Acceptable Values_: `(1.0, MAX_DOUBLE)`
 
 **`force`**
 

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -46,6 +46,12 @@ ROS parameters specific to the nodes in the local_pathfinding package.
 - _Datatype_: `float`
 - _Range_: `(0.0, MAX_DOUBLE)`
 
+**`write`**
+
+- _Description_: Whether or not to write a generated global path to a new csv file.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
 ## Boat Simulator Parameters
 
 ROS parameters specific to the nodes in the boat simulator.

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -10,6 +10,7 @@ mgp_main:
       global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
       interval_spacing: 30.0
       write: false
+      gps_threshold: 20.0
 
 # boat_simulator parameters
 low_level_control_node:

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -10,7 +10,7 @@ mgp_main:
       global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
       interval_spacing: 30.0
       write: false
-      gps_threshold: 2.0
+      gps_threshold: 1.5
       force: false
 
 # boat_simulator parameters

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -11,6 +11,7 @@ mgp_main:
       interval_spacing: 30.0
       write: false
       gps_threshold: 2.0
+      force: false
 
 # boat_simulator parameters
 low_level_control_node:

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -9,6 +9,7 @@ mgp_main:
    ros__parameters:
       global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
       interval_spacing: 30.0
+      write: false
 
 # boat_simulator parameters
 low_level_control_node:

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -10,7 +10,7 @@ mgp_main:
       global_path_filepath: "/workspaces/sailbot_workspace/src/local_pathfinding/global_paths/mock_global_path.csv"
       interval_spacing: 30.0
       write: false
-      gps_threshold: 20.0
+      gps_threshold: 2.0
 
 # boat_simulator parameters
 low_level_control_node:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
Linked to Issue [49](https://github.com/UBCSailbot/local_pathfinding/issues/49) in Local Pathfinding.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->

The purpose was to add a parameter to determine whether the generate_path function in node_mock_global_path.py should write a generated path to a new csv file.

The added parameter is:
`write`

### Verification
1. Run the global or local pathfinding launch file with development mode (default)
    ```
    ros2 launch local_pathfinding main_launch.py
    ```
2. In a different terminal run some ros2 param commands
    ```
    ros2 param get /mgp_main global_path_filepath
    ros2 param set /mgp_main global_path_filepath /workspaces/sailbot_workspace/src/local_pathfinding/global_paths/path_2.csv
    ```

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- [Link](https://github.com/UBCSailbot/local_pathfinding/pull/61) to the PR for this issue.