### PR TITLE
Fix run_virtual_iridium.sh

### DIFF
--- a/run_virtual_iridium.sh
+++ b/run_virtual_iridium.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # README under sailbot_workspace/src/network_systems/scripts/
 
-WEBHOOK_SERVER_ENDPOINT=${1:-127.0.0.1:8081}
+WEBHOOK_SERVER_ENDPOINT=${1:-"http://127.0.0.1:8081"}
 VIRTUAL_IRIDIUM_HTTP_SERVER_PORT=${2:-8080}
 
 # Make sure everything is killed on exit


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- The default argument for `--webhook-server-endpoint` has the incorrect format. Virtual Iridium crashes when running the Local Transceiver without this fix.
- @Jng468 you'll need to pull from sailbot_workspace main after this is merged.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [ ] 

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- 
