### PR TITLE
Use rrtstar planner in tests

### DIFF
--- a/src/local_pathfinding/test/test_ompl_path.py
+++ b/src/local_pathfinding/test/test_ompl_path.py
@@ -15,7 +15,7 @@ PATH = ompl_path.OMPLPath(
         ais_ships=AISShips(),
         global_path=Path(),
         filtered_wind_sensor=WindSensor(),
-        planner="bitstar",
+        planner="rrtstar",
     ),
 )
 


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
Previously we were using bitstar. Informed tree planners require a cost to go heuristic which we do not provide, which cause a warning to appear in our tests. I have switched the planner used in our tests to rrtstar until we have implemented the heuristic (@akash-venkateshwaran is exploring this in his project).
