### PR TITLE
Remove legacy-peer-deps header when installing node packages for website

### DIFF
--- a/.devcontainer/website/website.Dockerfile
+++ b/.devcontainer/website/website.Dockerfile
@@ -17,4 +17,4 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 # Adapted from https://www.digitalocean.com/community/tutorials/how-to-build-a-node-js-application-with-docker
 WORKDIR /website
 EXPOSE 3005
-CMD npm install --legacy-peer-deps && npm run dev
+CMD npm install && npm run dev

--- a/src/website/package-lock.json
+++ b/src/website/package-lock.json
@@ -17,7 +17,7 @@
         "leaflet-geometryutil": "^0.10.2",
         "mongodb": "^4.8.1",
         "mongoose": "^7.5.0",
-        "next": "*",
+        "next": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",

--- a/src/website/package-lock.json
+++ b/src/website/package-lock.json
@@ -17,7 +17,7 @@
         "leaflet-geometryutil": "^0.10.2",
         "mongodb": "^4.8.1",
         "mongoose": "^7.5.0",
-        "next": "latest",
+        "next": "^14.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",

--- a/src/website/package.json
+++ b/src/website/package.json
@@ -20,7 +20,7 @@
     "leaflet-geometryutil": "^0.10.2",
     "mongodb": "^4.8.1",
     "mongoose": "^7.5.0",
-    "next": "latest",
+    "next": "^14.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
A weird side-effect occurs in the `package-lock.json` file when we run `npm install` using the header `--legacy-peer-deps`. The header is no longer needed, so I'm removing it from the Dockerfile for the website.  

Also, I'm setting next.js to a fixed version. It's not good to install the "latest" version on every build - we want control over exactly which packages update and how that update happens.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Rebuilt the containers, the website still functions fine. 
