### PR TITLE
Update website base image to node:20-alpine

### DIFF
--- a/.devcontainer/website/website.Dockerfile
+++ b/.devcontainer/website/website.Dockerfile
@@ -1,7 +1,3 @@
-# Copied from https://github.com/microsoft/vscode-dev-containers/blob/5a084a93b0736ea86395ac99019a5b72a00b6341/containers/javascript-node-mongo/.devcontainer/Dockerfile
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-# ARG VARIANT=20
-# FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 FROM node:20-alpine
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/website/website.Dockerfile
+++ b/.devcontainer/website/website.Dockerfile
@@ -1,7 +1,8 @@
 # Copied from https://github.com/microsoft/vscode-dev-containers/blob/5a084a93b0736ea86395ac99019a5b72a00b6341/containers/javascript-node-mongo/.devcontainer/Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=20
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+# ARG VARIANT=20
+# FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+FROM node:20-alpine
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #334 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->

Changing the base image to node-alpine. Alpine is better as it's faster and more lightweight compared to the official node images (which come with preset libraries). 


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Tests all pass.
- Website functions fine. 

### Resources
<!-- Link to any resources that are relevant to this PR. -->
- https://hub.docker.com/_/node
- https://stackoverflow.com/questions/53024267/docker-are-node-alpine-images-at-the-end-smaller-than-full-node-images
