### PR TITLE
Combine docs-deploy and docs-delete jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
 
   # https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
   docs-update:
-    name: Deploy and/or Delete Docs versions
+    name: Update docs site
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,6 @@ jobs:
 
   # https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
   docs-update:
-    name: Update docs site
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     # default types and closed
     types: [opened, synchronize, reopened, closed]
-  workflow_dispatch:
 
 jobs:
   # https://github.com/nosborn/github-action-markdown-cli
@@ -60,7 +59,6 @@ jobs:
   docs-update:
     name: Deploy and/or Delete Docs versions
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event.action != 'closed') || (github.event_name == 'pull_request' && github.event.action == 'closed')
     permissions:
       contents: write
     steps:
@@ -76,7 +74,7 @@ jobs:
         run: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.docs.yml up -d
 
       - name: Build docs
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        if: github.event_name == 'push' || github.event.action != 'closed'
         shell: bash
         run: docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "mkdocs build"
 
@@ -101,7 +99,7 @@ jobs:
             mike deploy --push pr-${{ github.event.number }}"
 
       - name: Deploy main version of the Docs
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,10 +57,10 @@ jobs:
           ROOT: './docs/'
 
   # https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
-  docs-deploy:
-    name: Deploy Docs version
+  docs-update:
+    name: Deploy and/or Delete Docs versions
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    if: (github.event_name != 'pull_request' || github.event.action != 'closed') || (github.event_name == 'pull_request' && github.event.action == 'closed')
     permissions:
       contents: write
     steps:
@@ -76,11 +76,22 @@ jobs:
         run: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.docs.yml up -d
 
       - name: Build docs
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
         shell: bash
         run: docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "mkdocs build"
 
+      - name: "Delete pr-${{ github.event.number }} version of the Docs"
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        shell: bash
+        run: |
+          docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
+            git fetch && \
+            git config user.name ci-bot && \
+            git config user.email ci-bot@example.com && \
+            mike delete pr-${{ github.event.number }}"
+
       - name: "Deploy pr-${{ github.event.number }} version of the Docs"
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
         shell: bash
         run: |
           docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
@@ -98,30 +109,3 @@ jobs:
             git config user.name ci-bot && \
             git config user.email ci-bot@example.com && \
             mike deploy --push --update-aliases main latest"
-
-  docs-delete:
-    name: Delete Docs version
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    permissions:
-      contents: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          # checkout all commits to get accurate page revision times
-          # for the git-revision-date-localized plugin
-          fetch-depth: '0'
-
-      - name: Start containers
-        shell: bash
-        run: docker compose -f .devcontainer/docker-compose.yml -f .devcontainer/docker-compose.docs.yml up -d
-
-      - name: "Delete pr-${{ github.event.number }} version of the Docs"
-        shell: bash
-        run: |
-          docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
-            git fetch && \
-            git config user.name ci-bot && \
-            git config user.email ci-bot@example.com && \
-            mike delete --push pr-${{ github.event.number }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,7 @@ jobs:
         shell: bash
         run: |
           docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
+            git fetch && \
             git config user.name ci-bot && \
             git config user.email ci-bot@example.com && \
             mike deploy --push pr-${{ github.event.number }}"
@@ -93,6 +94,7 @@ jobs:
         shell: bash
         run: |
           docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
+            git fetch && \
             git config user.name ci-bot && \
             git config user.email ci-bot@example.com && \
             mike deploy --push --update-aliases main latest"
@@ -119,6 +121,7 @@ jobs:
         shell: bash
         run: |
           docker compose -f .devcontainer/docker-compose.yml exec -T docs /bin/sh -c "\
+            git fetch && \
             git config user.name ci-bot && \
             git config user.email ci-bot@example.com && \
             mike delete --push pr-${{ github.event.number }}"


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- After #351 the docs deploy and delete jobs run slower since they have to pull and run in a container
- Since they both ran when a PR is merged (one when PR is closed, another on push to main), there was often push conflicts: https://github.com/UBCSailbot/sailbot_workspace/actions/runs/8552838434/job/23434784662#step:6:17
- To resolve this, do everything in one job, and only push on deploy
