### PR TITLE
Changed Port for Posting Global Paths in Tests

### DIFF
--- a/src/local_pathfinding/local_pathfinding/global_path.py
+++ b/src/local_pathfinding/local_pathfinding/global_path.py
@@ -140,11 +140,12 @@ def get_path(file_path: str) -> Path:
     return path
 
 
-def post_path(path: Path) -> bool:
+def post_path(path: Path, url: str = PATH_URL) -> bool:
     """Sends the global path to NET via POST request.
 
     Args:
         path (Path): The global path.
+        url (str): URL to post path to. Should always use default value except for tests.
 
     Returns:
         bool: Whether or not the global path was successfully posted.
@@ -160,8 +161,9 @@ def post_path(path: Path) -> bool:
     data = {"waypoints": waypoints, "timestamp": timestamp}
 
     json_data = json.dumps(data).encode("utf-8")
+
     try:
-        urlopen(PATH_URL, json_data)
+        urlopen(url, json_data)
         return True
     except HTTPError as http_error:
         print(f"HTTP Error: {http_error.code}")

--- a/src/local_pathfinding/test/post_server.py
+++ b/src/local_pathfinding/test/post_server.py
@@ -8,6 +8,9 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+TEST_PORT = 8085
+POST_TEST_URL = "http://localhost:" + str(TEST_PORT) + "/global-path"
+
 
 class CustomRequestHandler(BaseHTTPRequestHandler):
     def _set_response(self, status_code=200, content_type="application/json"):
@@ -32,7 +35,7 @@ class CustomRequestHandler(BaseHTTPRequestHandler):
         )
 
 
-def run_server(port=8081) -> HTTPServer:
+def run_server(port=TEST_PORT) -> HTTPServer:
     server_address = ("localhost", port)
     httpd = HTTPServer(server_address, CustomRequestHandler)
 

--- a/src/local_pathfinding/test/test_global_path.py
+++ b/src/local_pathfinding/test/test_global_path.py
@@ -1,6 +1,6 @@
 import os
 
-import post_server
+import post_server as ps
 import pytest
 from custom_interfaces.msg import HelperLatLon, Path
 
@@ -338,11 +338,11 @@ def test_post_path(global_path: Path):
     """
 
     # Launch http server
-    server = post_server.run_server()
+    server = ps.run_server()
 
-    assert post_path(global_path), "Failed to post global path"
+    assert post_path(global_path, url=ps.POST_TEST_URL), "Failed to post global path"
 
-    post_server.shutdown_server(httpd=server)
+    ps.shutdown_server(httpd=server)
 
 
 # ------------------------- TEST WRITE_TO_FILE ------------------------------


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #363 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Moved the test post_server from port 8081 to 8085.
Also refactored the test files a bit so that we only need to change one line to change the test port again if needed.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Ran the test task, but the local path tests might be running before NET on my machine