### PR TITLE
Fix warning from test_controllers unit test

### DIFF
--- a/src/controller/tests/unit/wingsail/test_controllers.py
+++ b/src/controller/tests/unit/wingsail/test_controllers.py
@@ -6,12 +6,12 @@ from controller.common.lut import LUT
 from controller.wingsail.controllers import WingsailController
 
 # Define test data
-test_lut_data = np.array(
+sample_lut_data = np.array(
     [[50000, 5.75], [100000, 6.75], [200000, 7], [500000, 9.25], [1000000, 10]]
 )
-test_lut = LUT(test_lut_data)
-test_chord_width = CHORD_WIDTH_MAIN_SAIL
-test_kinematic_viscosity = KINEMATIC_VISCOSITY
+sample_lut = LUT(sample_lut_data)
+sample_chord_width = CHORD_WIDTH_MAIN_SAIL
+sample_kinematic_viscosity = KINEMATIC_VISCOSITY
 
 
 class TestWingsailController:
@@ -24,7 +24,7 @@ class TestWingsailController:
         """
         Fixture to create an instance of WingsailController for testing.
         """
-        return WingsailController(test_chord_width, test_kinematic_viscosity, test_lut)
+        return WingsailController(sample_chord_width, sample_kinematic_viscosity, sample_lut)
 
     @pytest.mark.parametrize(
         "apparent_wind_speed, expected_reynolds_number",


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Fixed an issue with one of the controller tests that was giving a warning:

![Screenshot 2024-06-03 at 10 51 56 PM](https://github.com/UBCSailbot/sailbot_workspace/assets/112828024/6beb5cd6-73b0-4fe8-8bbd-66c91ef37ee9)

- It seems that this issue was caused by one of the variable names starting with 'test', leading pytest to mistakenly try to collect it as a test or fixture.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Re-ran controller unit tests.

![Screenshot 2024-06-03 at 10 53 27 PM](https://github.com/UBCSailbot/sailbot_workspace/assets/112828024/1625c1a4-2289-484b-9a6b-6da9d15a5e86)
