### PR TITLE
Fix disabling dependabot updates for website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,17 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  # Disable dependabot for website dependencies
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/src/website"
     schedule:
       interval: "weekly"
-    # Disable all pull requests for npm dependencies
+    open-pull-requests-limit: 0
+  # Disable dependabot for website test dependencies
+  - package-ecosystem: "npm"
+    directory: "/src/website/tests"
+    schedule:
+      interval: "weekly"
     open-pull-requests-limit: 0
     # # Create a group of dependencies to be updated together in one pull request
     # groups:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
John wanted dependabot updates to be disabled for the website and for its dependencies to be updated manually (https://github.com/UBCSailbot/sailbot_workspace/issues/362), but my original implementation didn't work. Hopefully this PR fixes that. You can manually close https://github.com/UBCSailbot/sailbot_workspace/pull/408 or merge it in, up to you
