### PR TITLE
Resolved Markdown Link Check Failure by Accepting 403 Response as a Live Link

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -21,5 +21,7 @@
         {
             "pattern": "^https://linuxize.com*"
         }
-    ]
+    ],
+
+    "aliveStatusCodes": [403, 200]
 }


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->

The `docs.yml` workflow is failing because the following link returns a `403 Forbidden` repsonse when the link checker requests the website. 

[https://www.toptal.com/robotics/introduction-to-robot-operating-system](https://www.toptal.com/robotics/introduction-to-robot-operating-system)

A 403 response means the server understands the request but refuses to fulfill it.
The link works fine with a browser, so the maintainers of **Toptal** likely are blocking any user agents that are not web browsers.

Ie. this command returns 403 
`wget https://www.toptal.com/robotics/introduction-to-robot-operating-system`
and this command returns 200
`wget --user-agent="Chrome/58.0.3029.110" https://www.toptal.com/robotics/introduction-to-robot-o
perating-system`

We're not going to spoof user agents, especially not just to check if a link is live. Therefore I suggest we treat links that get 403 responses as live.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Verify that docs workflow passes on this PR
