### PR TITLE
Fix view and edit source links in docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_author: UBCSailbot Software Team
 # Repository
 repo_name: UBCSailbot/sailbot_workspace
 repo_url: https://github.com/UBCSailbot/sailbot_workspace
-edit_uri: "edit/main/sailbot_workspace/"
+edit_uri: "edit/main/docs/"
 
 # Configuration
 theme:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
- The edit URI incorrect so it didn't open the right link; this PR should fix that

<img width="652" alt="image" src="https://github.com/user-attachments/assets/77ef380b-ea73-4f4e-9eb3-b467d9c5b25f">

