### PR TITLE
Updated physics engine to use wind sensor

### DIFF
--- a/src/boat_simulator/boat_simulator/common/constants.py
+++ b/src/boat_simulator/boat_simulator/common/constants.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Dict
 
 import numpy as np
+from numpy.typing import NDArray
 
 
 # Class declarations for constants. These are not meant to be accessed directly.
@@ -44,7 +45,7 @@ class BoatProperties:
     rudder_dist: float  # Meters
     hull_drag_factor: float  # Dimensionless
     mass: float  # Kilograms
-    inertia: np.ndarray  # Kilogram meter squared
+    inertia: NDArray[np.float64]  # Kilogram meter squared
 
 
 # Directly accessible constants

--- a/src/boat_simulator/boat_simulator/common/constants.py
+++ b/src/boat_simulator/boat_simulator/common/constants.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict
 
+import numpy as np
+
 
 # Class declarations for constants. These are not meant to be accessed directly.
 @dataclass
@@ -41,6 +43,8 @@ class BoatProperties:
     sail_dist: float  # Meters
     rudder_dist: float  # Meters
     hull_drag_factor: float  # Dimensionless
+    mass: float  # Kilograms
+    inertia: np.ndarray  # Kilogram meter squared
 
 
 # Directly accessible constants
@@ -92,4 +96,6 @@ BOAT_PROPERTIES = BoatProperties(
     sail_dist=5.0,
     rudder_dist=1.5,
     hull_drag_factor=0.05,
+    mass=200.0,
+    inertia=np.array([[10, 0, 0], [0, 30, 0], [0, 0, 20]], dtype=np.float32),
 )

--- a/src/boat_simulator/boat_simulator/nodes/physics_engine/physics_engine_node.py
+++ b/src/boat_simulator/boat_simulator/nodes/physics_engine/physics_engine_node.py
@@ -111,7 +111,7 @@ class PhysicsEngineNode(Node):
         self.__sail_trim_tab_angle = 0
         self.__desired_heading = None
         self.__boat_state = BoatState(
-            0.5, 1, np.array([[0.5, 0.5, 0.5], [0.0, 0.5, 0.5], [0.0, 0.0, 0.5]], dtype=np.float32)
+            0.5, Constants.BOAT_PROPERTIES.mass, Constants.BOAT_PROPERTIES.inertia
         )
         self.__wind_generator = FluidGenerator(
             generator=MVGaussianGenerator(np.array([5, 5]), np.array([[2, 1], [1, 2]]))


### PR DESCRIPTION
- Created a private instance of the `WindSensor` class in the physics engine node.
- Added a new private method: `__update_wind_sensor()`. This method updates the `wind` attribute of the `WindSensor` instance using the wind generator (`self.__wind_generator`).
- Integrated `__update_wind_sensor()` call right before `self.__update_boat_state()` in the `__publish()` function.
- Modified the `self.__update_boat_state()` method to use data from the `WindSensor` instead of the wind generator, introducing realistic noise into the simulation.
- Resolves #426
