### PR TITLE
Fix dead link in setup instructions

### DIFF
--- a/docs/current/sailbot_workspace/usage/setup.md
+++ b/docs/current/sailbot_workspace/usage/setup.md
@@ -21,7 +21,7 @@ allowing it to be installed on Windows and macOS in addition to Linux.
 
 [^1]: [Wikipedia Docker page](https://en.wikipedia.org/wiki/Docker_(software)){target=_blank}
 [^2]: [Get Docker](https://docs.docker.com/get-docker/){target=_blank}
-[^3]: [What is the difference between Docker Desktop for Linux and Docker Engine](https://docs.docker.com/desktop/faqs/linuxfaqs/#what-is-the-difference-between-docker-desktop-for-linux-and-docker-engine){target=_blank}
+[^3]: [What is the difference between Docker Desktop for Linux and Docker Engine](https://www.docker.com/blog/how-to-check-docker-version/){target=_blank}
 
 === ":material-microsoft-windows: Windows"
 

--- a/docs/current/sailbot_workspace/usage/setup.md
+++ b/docs/current/sailbot_workspace/usage/setup.md
@@ -21,7 +21,7 @@ allowing it to be installed on Windows and macOS in addition to Linux.
 
 [^1]: [Wikipedia Docker page](https://en.wikipedia.org/wiki/Docker_(software)){target=_blank}
 [^2]: [Get Docker](https://docs.docker.com/get-docker/){target=_blank}
-[^3]: [What is the difference between Docker Desktop for Linux and Docker Engine](https://www.docker.com/blog/how-to-check-docker-version/){target=_blank}
+[^3]: [What is the difference between Docker Desktop for Linux and Docker Engine](https://www.docker.com/blog/how-to-check-docker-version){target=_blank}
 
 === ":material-microsoft-windows: Windows"
 


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
- Dead link in setup instructions: https://docs.docker.com/desktop/faqs/linuxfaqs/#what-is-the-difference-between-docker-desktop-for-linux-and-docker-engine
<img width="1392" alt="Screenshot 2024-11-16 at 1 01 29 PM" src="https://github.com/user-attachments/assets/d4b93c64-2ccc-4a36-9ae4-9fd9a41477f1">

- Replaced with https://www.docker.com/blog/how-to-check-docker-version

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Link check ci job
