### PR TITLE
Fix markdown formatter configuration

### DIFF
--- a/sailbot.code-workspace
+++ b/sailbot.code-workspace
@@ -261,7 +261,7 @@
             "editor.renderWhitespace": "trailing",
             "cSpell.fixSpellingWithRenameProvider": true,
             "cSpell.advanced.feature.useReferenceProviderWithRename": true,
-            "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/",
+            "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"
         },
         "markdownlint.config": {
             "extends": "/workspaces/sailbot_workspace/.markdownlint.json"

--- a/sailbot.code-workspace
+++ b/sailbot.code-workspace
@@ -263,6 +263,7 @@
             "cSpell.advanced.feature.useReferenceProviderWithRename": true,
             "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"
         },
+        "markdown.extension.list.indentationSize": "inherit",
         "markdownlint.config": {
             "extends": "/workspaces/sailbot_workspace/.markdownlint.json"
         },

--- a/sailbot.code-workspace
+++ b/sailbot.code-workspace
@@ -261,7 +261,10 @@
             "editor.renderWhitespace": "trailing",
             "cSpell.fixSpellingWithRenameProvider": true,
             "cSpell.advanced.feature.useReferenceProviderWithRename": true,
-            "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"
+            "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/",
+        },
+        "markdownlint.config": {
+            "extends": "/workspaces/sailbot_workspace/.markdownlint.json"
         },
 
         // yaml


### PR DESCRIPTION
### Description

The markdown formatter currently defaults to 2-space indentation, while the linter expects 4-space indentation. This mismatch causes the Markdown lint CI to fail and makes it hard for users to address the issue, as the auto-formatter reverts changes back to 2 spaces.

<img width="1261" alt="Screenshot 2024-11-30 at 12 01 05 PM" src="https://github.com/user-attachments/assets/eda98bd0-25ac-44da-8c89-2df2b1144287">

### Verification
#### Steps Taken:
- Updated the workspace settings to use the markdownlint configurations.
- Verified that the formatter now follows the linter's configuration and uses 4 spaces for indentation.