### PR TITLE
Raghumanimehta/485 removing ompl path state constructor

### DIFF
--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -11,11 +11,10 @@ from local_pathfinding.ompl_path import OMPLPath
 class LocalPathState:
     """Gathers and stores the state of Sailbot.
     The attributes' units and conventions can be found in the ROS msgs they are derived from in the
-    custom_interfaces repository.
+    custom_interfaces package.
 
     Attributes:
-    #TODO:
-        `position` HelperLatLon: Latitude and longitude of Sailbot.
+        `position` (HelperLatLon): Latitude and longitude of Sailbot.
         `speed` (float): Speed of Sailbot.
         `heading` (float): Direction that Sailbot is pointing.
         `ais_ships` (List[HelperAISShip]): Information about nearby ships.
@@ -24,9 +23,7 @@ class LocalPathState:
         `wind_speed` (float): Wind speed.
         `wind_direction` (int): Wind direction.
         `planner` (str): Planner to use for the OMPL query.
-        `reference (HelperLatLon): Lat and lon position of the next global waypoint. (
-            added for convenience in the OMPLPath class after removing the OMPLPathState class
-        )
+        `reference (HelperLatLon): Lat and lon position of the next global waypoint.
     """
 
     def __init__(
@@ -35,7 +32,7 @@ class LocalPathState:
         ais_ships: AISShips,
         global_path: Path,
         filtered_wind_sensor: WindSensor,
-        planner: str
+        planner: str,
     ):
         """Initializes the state from ROS msgs."""
         if gps:  # TODO: remove when mock can be run
@@ -63,9 +60,7 @@ class LocalPathState:
             self.wind_direction = filtered_wind_sensor.direction
 
         self.reference_latlon = (
-            self.global_path[-1]
-            if self.global_path
-            else HelperLatLon(latitude=0.0, longitude=0.0)
+            self.global_path[-1] if self.global_path else HelperLatLon(latitude=0.0, longitude=0.0)
         )
 
         self.planner = planner

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -23,6 +23,7 @@ class LocalPathState:
         `wind_speed` (float): Wind speed.
         `wind_direction` (int): Wind direction.
         `planner` (str): Planner to use for the OMPL query.
+        `reference_latlon` (Tuple[float, float]): The last tuple from the global_path array
     """
 
     def __init__(
@@ -31,7 +32,7 @@ class LocalPathState:
         ais_ships: AISShips,
         global_path: Path,
         filtered_wind_sensor: WindSensor,
-        planner: str,
+        planner: str
     ):
         """Initializes the state from ROS msgs."""
         if gps:  # TODO: remove when mock can be run
@@ -53,6 +54,12 @@ class LocalPathState:
         if filtered_wind_sensor:  # TODO: remove when mock can be run
             self.wind_speed = filtered_wind_sensor.speed.speed
             self.wind_direction = filtered_wind_sensor.direction
+
+        self.reference_latlon = (
+            self.global_path[-1]
+            if self.global_path and len(self.global_path) > 0
+            else HelperLatLon(latitude=0.0, longitude=0.0)
+        )
 
         self.planner = planner
 

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -14,7 +14,8 @@ class LocalPathState:
     custom_interfaces repository.
 
     Attributes:
-        `position` (Tuple[float, float]): Latitude and longitude of Sailbot.
+    #TODO:
+        `position` HelperLatLon: Latitude and longitude of Sailbot.
         `speed` (float): Speed of Sailbot.
         `heading` (float): Direction that Sailbot is pointing.
         `ais_ships` (List[HelperAISShip]): Information about nearby ships.
@@ -23,7 +24,7 @@ class LocalPathState:
         `wind_speed` (float): Wind speed.
         `wind_direction` (int): Wind direction.
         `planner` (str): Planner to use for the OMPL query.
-        `reference_latlon` (Tuple[float, float]): The last tuple from the global_path array (
+        `reference (HelperLatLon): Lat and lon position of the next global waypoint. (
             added for convenience in the OMPLPath class after removing the OMPLPathState class
         )
     """
@@ -38,9 +39,13 @@ class LocalPathState:
     ):
         """Initializes the state from ROS msgs."""
         if gps:  # TODO: remove when mock can be run
-            self.position = (gps.lat_lon.latitude, gps.lat_lon.longitude)
+            self.position = gps.lat_lon
             self.speed = gps.speed.speed
             self.heading = gps.heading.heading
+        else:
+            self.position = HelperLatLon(latitude=0.0, longitude=0.0)
+            self.speed = 0.0
+            self.heading = 0.0
 
         if ais_ships:  # TODO: remove when mock can be run
             self.ais_ships = [ship for ship in ais_ships.ships]
@@ -59,7 +64,7 @@ class LocalPathState:
 
         self.reference_latlon = (
             self.global_path[-1]
-            if self.global_path and len(self.global_path) > 0
+            if self.global_path
             else HelperLatLon(latitude=0.0, longitude=0.0)
         )
 

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -2,7 +2,14 @@
 
 from typing import List, Optional, Tuple
 
-from custom_interfaces.msg import GPS, AISShips, HelperLatLon, Path, WindSensor
+from custom_interfaces.msg import (
+    GPS,
+    AISShips,
+    HelperLatLon,
+    HelperSpeed,
+    Path,
+    WindSensor,
+)
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 from local_pathfinding.ompl_path import OMPLPath
@@ -58,6 +65,9 @@ class LocalPathState:
         if filtered_wind_sensor:  # TODO: remove when mock can be run
             self.wind_speed = filtered_wind_sensor.speed.speed
             self.wind_direction = filtered_wind_sensor.direction
+        else:
+            self.wind_speed = HelperSpeed(speed=0.0)
+            self.wind_direction = 0
 
         self.reference_latlon = (
             self.global_path[-1] if self.global_path else HelperLatLon(latitude=0.0, longitude=0.0)

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -23,7 +23,9 @@ class LocalPathState:
         `wind_speed` (float): Wind speed.
         `wind_direction` (int): Wind direction.
         `planner` (str): Planner to use for the OMPL query.
-        `reference_latlon` (Tuple[float, float]): The last tuple from the global_path array
+        `reference_latlon` (Tuple[float, float]): The last tuple from the global_path array (
+            added for convenience in the OMPLPath class after removing the OMPLPathState class
+        )
     """
 
     def __init__(

--- a/src/local_pathfinding/local_pathfinding/ompl_path.py
+++ b/src/local_pathfinding/local_pathfinding/ompl_path.py
@@ -120,12 +120,12 @@ class OMPLPath:
 
         if not self.state.global_path:
             goal_polygon = self.create_buffer_around_position(cs.XY(0, 0))
-            goal_x, goal_y = (0, 0)
+            goal_x, goal_y = (0.0, 0.0)
         else:
             goal_position = self.state.global_path[-1]
             goal_position_in_xy = cs.latlon_to_xy(self.state.reference_latlon, goal_position)
             goal_polygon = self.create_buffer_around_position(goal_position_in_xy)
-            goal_x, goal_y = (int(goal_position_in_xy.x), int(goal_position_in_xy.y))
+            goal_x, goal_y = goal_position_in_xy
 
         # create an SE2 state space: rotation and translation in a plane
         space = pyompl.SE2StateSpace()

--- a/src/local_pathfinding/local_pathfinding/ompl_path.py
+++ b/src/local_pathfinding/local_pathfinding/ompl_path.py
@@ -114,7 +114,7 @@ class OMPLPath:
 
         # Create buffered spaces and extract their centers
         start_position_in_xy = cs.latlon_to_xy(self.state.reference_latlon, self.state.position)
-        state_domain = self.create_buffer_around_position(start_position_in_xy)
+        start_box = self.create_buffer_around_position(start_position_in_xy)
         start_x = start_position_in_xy.x
         start_y = start_position_in_xy.y
 
@@ -132,7 +132,7 @@ class OMPLPath:
 
         # set the bounds of the state space
         bounds = pyompl.RealVectorBounds(dim=2)
-        state_space = box(*MultiPolygon([state_domain, goal_polygon]).bounds)
+        state_space = box(*MultiPolygon([start_box, goal_polygon]).bounds)
         x_min, y_min, x_max, y_max = state_space.bounds
 
         if x_max <= x_min or y_max <= y_min:

--- a/src/local_pathfinding/test/test_ompl_path.py
+++ b/src/local_pathfinding/test/test_ompl_path.py
@@ -19,24 +19,24 @@ PATH = ompl_path.OMPLPath(
     ),
 )
 
-
-def test_OMPLPathState():
-    local_path_state = LocalPathState(
-        gps=GPS(),
-        ais_ships=AISShips(),
-        global_path=Path(),
-        filtered_wind_sensor=WindSensor(),
-        planner="rrtstar",
-    )
-    state = ompl_path.OMPLPathState(local_path_state, logger=RcutilsLogger())
-    assert state.state_domain == (-1, 1), "incorrect value for attribute state_domain"
-    assert state.state_range == (-1, 1), "incorrect value for attribute start_state"
-    assert state.start_state == pytest.approx(
-        (0.5, 0.4)
-    ), "incorrect value for attribute start_state"
-    assert state.goal_state == pytest.approx(
-        (0.5, -0.4)
-    ), "incorrect value for attribute goal_state"
+# TODO: Update this test
+# def test_OMPLPathState():
+#     local_path_state = LocalPathState(
+#         gps=GPS(),
+#         ais_ships=AISShips(),
+#         global_path=Path(),
+#         filtered_wind_sensor=WindSensor(),
+#         planner="rrtstar",
+#     )
+#     state = local_path_state
+#     # assert state.state_domain == (-1, 1), "incorrect value for attribute state_domain"
+#     # assert state.state_range == (-1, 1), "incorrect value for attribute start_state"
+#     # assert state.start_state == pytest.approx(
+#     #     (0.5, 0.4)
+#     # ), "incorrect value for attribute start_state"
+#     # assert state.goal_state == pytest.approx(
+#     #     (0.5, -0.4)
+#     # ), "incorrect value for attribute goal_state"
 
 
 def test_OMPLPath___init__():
@@ -50,8 +50,7 @@ def test_OMPLPath_get_cost():
 
 def test_OMPLPath_get_waypoint():
     waypoints = PATH.get_waypoints()
-
-    waypoint_XY = cs.XY(*PATH.state.start_state)
+    waypoint_XY = cs.XY(PATH.state.position[0], PATH.state.position[1])
     start_state_latlon = cs.xy_to_latlon(PATH.state.reference_latlon, waypoint_XY)
 
     test_start = waypoints[0]

--- a/src/local_pathfinding/test/test_ompl_path.py
+++ b/src/local_pathfinding/test/test_ompl_path.py
@@ -1,6 +1,6 @@
 import pyompl
 import pytest
-from custom_interfaces.msg import GPS, AISShips, HelperLatLon, Path, WindSensor
+from custom_interfaces.msg import GPS, AISShips, Path, WindSensor
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from shapely.geometry import Point
 


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #485 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
OMPLPathState class has been removed. Some of its fields have been moved as local variables to `_init_simple_setup` in `ompl_path.py` since only this method used those fields. The rest of the fields could be derived from `local_path_state` and have not been changed. Logic to calculate `state_domain` and `state_range` in `ompl_path.py` has been added. 

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Tested the system before and after refactoring.  


