### PR TITLE
Init LocalPathState.ais_ships as an empty list to prevent AttributeError on ros launch

### DIFF
--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -56,7 +56,7 @@ class LocalPathState:
         if ais_ships:  # TODO: remove when mock can be run
             self.ais_ships = [ship for ship in ais_ships.ships]
         else:
-            ais_ships = None
+            ais_ships = []  # ensures this attribute is always set, to avoid AtributeError
 
         if global_path:  # TODO: remove when mock can be run
             self.global_path = [


### PR DESCRIPTION
Sometimes when you launch ros, the mock ais data wont be received in time and the ais_ships attribute wont be initialized for a LocalPathState object which causes an error when trying to initialize obstacles in ompl_path.py.

This fixes that