### PR TITLE
Only run docs workflow when docs is modified plus once weekly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,18 @@
 name: Docs Site
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    # default types and closed
-    types: [opened, synchronize, reopened, closed]
+    push:
+      branches:
+        - main
+      paths:
+        - 'docs/**'
+    pull_request:
+      types: [opened, synchronize, reopened, closed]
+      paths:
+        - 'docs/**'
+    schedule:
+      - cron: '0 0 * * 0'  # Runs on main every Sunday at midnight UTC
+
 
 jobs:
   # https://github.com/nosborn/github-action-markdown-cli

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Our Dev Container configuration can be found in [`.devcontainer/`](https://githu
 
 ### VS Code Workspace
 
-[Workspaces](https://code.visualstudio.com/docs/editor/workspaces) are VS Code instances that contain one or more folders.
+[Workspaces](https://code.visualstudio.com/docs) are VS Code instances that contain one or more folders.
 Our workspace configuration file can be found at
 [`sailbot.code-workspace`](https://github.com/UBCSailbot/sailbot_workspace/blob/main/sailbot.code-workspace).
 


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #526 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
I am just going to run the docs workflow much less frequently so we don't have to keep rerunning the action when it runs out of memory.
