### PR TITLE
Report inactive subs instead of reporting all active by default

### DIFF
--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -202,7 +202,6 @@ class Sailbot(Node):
             self.planner = planner
 
     def _all_subs_active(self) -> bool:
-        return True  # TODO: this line is a placeholder, delete when mocks can be run
         return self.ais_ships and self.gps and self.global_path and self.filtered_wind_sensor
 
     def _log_inactive_subs_warning(self):


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
Just uncommented one line to. Now the navigate node will actually report in any subscribed data hasnt been received yet now that mock nodes are ready.