### PR TITLE
Update LPathData msg type and create new HelperObstacle msg type

### DIFF
--- a/src/custom_interfaces/CMakeLists.txt
+++ b/src/custom_interfaces/CMakeLists.txt
@@ -37,6 +37,7 @@ set(common_msg
   "msg/HelperLatLon.msg"
   "msg/HelperROT.msg"
   "msg/HelperSpeed.msg"
+  "msg/HelperObstacle.msg"
 )
 
 # Boat simulator custom messages

--- a/src/custom_interfaces/msg/HelperObstacle.msg
+++ b/src/custom_interfaces/msg/HelperObstacle.msg
@@ -1,0 +1,3 @@
+# the list of points that form the boundary of the obstacle, oriented CCW
+HelperLatLon[] points
+string obstacle_type # one of : {"Land", "Boat"}

--- a/src/custom_interfaces/msg/LPathData.msg
+++ b/src/custom_interfaces/msg/LPathData.msg
@@ -1,1 +1,8 @@
+Path global_path
 Path local_path
+GPS gps
+WindSensor filtered_wind_sensor
+AISShips ais_ships
+# contains Land and Boat obstacles differentiated by obstacle_type attribute
+HelperObstacle[] obstacles
+DesiredHeading desired_heading

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -152,7 +152,8 @@ class Sailbot(Node):
         self.get_logger().debug(f"Publishing to {self.desired_heading_pub.topic}: {msg}")
 
     def lpath_data_callback(self):
-        """Get and publish the local path."""
+        """Collect all navigation data and publish it in one message"""
+        raise NotImplementedError
 
         current_local_path = ci.Path(waypoints=self.local_path.waypoints)
 

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -29,7 +29,7 @@ class Sailbot(Node):
 
     Publishers:
         desired_heading_pub (Publisher): Publish the desired heading in a `DesiredHeading` msg.
-        lpath_data_pub (Publisher): Publish the local path in a `LPathData` msg.
+        lpath_data_pub (Publisher): Publish all local path data in a `LPathData` msg.
 
     Publisher timers:
         pub_period_sec (float): The period of the publisher timers.


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
We want the navigate node to publish all navigation data it has access to. This includes:

- global path
- local path
- gps
- windsensor
- AIS ships
- obstacles
- desired heading

Then our observer/visualizer node will subscribe to this message in order to access all the information available to the navigate node.

<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
Update the specification of the LPathData msg to include all the above data.

This PR is just for creating the new msg type `HelperObstacle.msg` and editing the `LPAthDat.msg` type to include all navigation data.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Successful creation of an LPathData msg with all data included.

To test the updated LPathData type compiled properly, I ran the following script
```
import custom_interfaces.msg as ci


def main():
    local_path_data = ci.LPathData(
        global_path=ci.Path(),
        local_path=ci.Path(),
        gps=ci.GPS(),
        filtered_wind_sensor=ci.WindSensor(),
        ais_ships=ci.AISShips(),
        obstacles=[ci.HelperObstacle(points=[ci.HelperLatLon()], obstacle_type="Land")],
        desired_heading=ci.DesiredHeading(),
    )

    print(local_path_data)


if __name__ == "__main__":
    main()

```