### PR TITLE
Added Self-update of Heading Based on ROT for Mock AIS Node

### DIFF
--- a/src/local_pathfinding/local_pathfinding/node_mock_ais.py
+++ b/src/local_pathfinding/local_pathfinding/node_mock_ais.py
@@ -75,10 +75,7 @@ class MockAISNode(Node):
         Update the ship's position based on its speed, heading and rate of turn (ROT)
         """
 
-        # TODO: update ship based on turnspeed as well
-
-        # Set heading, speed and time
-        heading = math.radians(ship.cog.heading)
+        # Get speed and time
         speed = ship.sog.speed / 3600
         time = self.timer_period
         ref = HelperLatLon(latitude=0.0, longitude=0.0)
@@ -86,14 +83,25 @@ class MockAISNode(Node):
             latitude=ship.lat_lon.latitude, longitude=ship.lat_lon.longitude
         )
 
-        # rot = ship.rot.rot
-        # # Convert ROT to degrees per minute
-        # if rot == -128:
-        #     rot_dpm = 0
-        # elif abs(rot) == 127:
-        #     rot_dpm = 10
-        # else:
-        #     rot_dpm = (abs(rot)/4.733) ** 2
+        # Get ROT in radians per second
+        rot = ship.rot.rot
+        if rot == -128:
+            rot_dpm = 0
+        elif abs(rot) == 127:
+            rot_dpm = 10
+        else:
+            rot_dpm = (rot / 4.733) ** 2
+        rot_rps = math.radians(rot_dpm / 60)
+        if rot < 0:
+            rot_rps *= -1
+
+        # Update heading
+        ship.cog.heading += math.degrees(rot_rps * time)
+        if ship.cog.heading > 180:
+            ship.cog.heading -= 360
+        elif ship.cog.heading <= -180:
+            ship.cog.heading += 360
+        heading = math.radians(ship.cog.heading)
 
         # Convert ship position to cartesian coordinates
         ship_cartesian = latlon_to_xy(ref, ship_latlon)


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
- Adds to #476 
- Updated the Mock AIS Node to update ship headings every `self.timer_period' based on rate of turn (ROT).

### Verification
- Manual verification that heading changes by a correct amount every `self.timer_period' given an initial heading and rot.