### PR TITLE
Change minimum turning objective to use heading-path method only

### DIFF
--- a/src/local_pathfinding/test/test_objectives.py
+++ b/src/local_pathfinding/test/test_objectives.py
@@ -45,57 +45,6 @@ def test_get_euclidean_path_length_objective(cs1: tuple, cs2: tuple, expected: f
 
 
 @pytest.mark.parametrize(
-    "method",
-    [
-        objectives.MinimumTurningMethod.GOAL_HEADING,
-        objectives.MinimumTurningMethod.GOAL_PATH,
-        objectives.MinimumTurningMethod.HEADING_PATH,
-    ],
-)
-def test_minimum_turning_objective(method: objectives.MinimumTurningMethod):
-    minimum_turning_objective = objectives.MinimumTurningObjective(
-        OMPL_PATH._simple_setup.getSpaceInformation(),
-        OMPL_PATH._simple_setup,
-        OMPL_PATH.state.heading,
-        method,
-    )
-    assert minimum_turning_objective is not None
-
-
-@pytest.mark.parametrize(
-    "cs1,sf,heading_degrees,expected",
-    [
-        ((0, 0), (0, 0), 0, 0),
-        ((-1, -1), (0.1, 0.2), 45, 2.490),
-    ],
-)
-def test_goal_heading_turn_cost(cs1: tuple, sf: tuple, heading_degrees: float, expected: float):
-    s1 = coord_systems.XY(*cs1)
-    goal = coord_systems.XY(*sf)
-    heading = math.radians(heading_degrees)
-    assert objectives.MinimumTurningObjective.goal_heading_turn_cost(
-        s1, goal, heading
-    ) == pytest.approx(expected, abs=1e-3)
-
-
-@pytest.mark.parametrize(
-    "cs1,cs2,sf,expected",
-    [
-        ((0, 0), (0, 0), (0, 0), 0),
-        ((-1, -1), (2, 1), (0.1, 0.2), 13.799),
-    ],
-)
-def test_goal_path_turn_cost(cs1: tuple, cs2: tuple, sf: tuple, expected: float):
-    s1 = coord_systems.XY(*cs1)
-    s2 = coord_systems.XY(*cs2)
-    goal = coord_systems.XY(*sf)
-
-    assert objectives.MinimumTurningObjective.goal_path_turn_cost(s1, s2, goal) == pytest.approx(
-        expected, abs=1e-3
-    )
-
-
-@pytest.mark.parametrize(
     "cs1,cs2,heading_degrees,expected",
     [
         ((0, 0), (0, 0), 0.0, 0),


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
Removed two of the methods for the MinimumTurningObjective that we are not going to use.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. --> 
All unit tests pass
Visual verification in the visualizer that the paths look pretty good, not too many turns.

