### PR TITLE
Setup port forwarding on port 3005 so the website can run on localhost when using a codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,13 @@
 	"name": "Sailbot Workspace",
 	"dockerComposeFile": [
 		"docker-compose.yml",
-		// "website/docker-compose.website.yml", // website
+		"website/docker-compose.website.yml", // website
 
 		// Uncomment the files containing the programs you need
 		// "docs/docker-compose.docs.yml", // docs
 	],
 	"service": "sailbot-workspace",
+    "forwardPorts": [3005],
 	"workspaceFolder": "/workspaces/sailbot_workspace",
 	"remoteUser": "ros",
 	"containerEnv": {


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
The purpose of this PR is to ensure the website is enabled on localhost when using a Codespace.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
Upon devcontainer create, the website is available on `http://127.0.0.1:3005/`

<img width="1576" height="873" alt="image" src="https://github.com/user-attachments/assets/78aaa608-2757-44ae-b286-0189180b4ae2" />
