### PR TITLE
Commented out invalid state logging in ompl path

### DIFF
--- a/src/local_pathfinding/local_pathfinding/ompl_path.py
+++ b/src/local_pathfinding/local_pathfinding/ompl_path.py
@@ -21,7 +21,10 @@ from shapely.geometry import MultiPolygon, Polygon, box
 
 import local_pathfinding.coord_systems as cs
 import local_pathfinding.obstacles as ob
-from local_pathfinding.ompl_objectives import get_sailing_objective, create_buffer_around_position
+from local_pathfinding.ompl_objectives import (
+    create_buffer_around_position,
+    get_sailing_objective,
+)
 
 if TYPE_CHECKING:
     from local_pathfinding.local_path import LocalPathState
@@ -345,10 +348,10 @@ class OMPLPath:
                     # uncomment this if you want to log which states are being labeled invalid
                     # its commented out for now to avoid unnecessary file I/O
 
-                    if isinstance(state, base.State):  # only happens in unit tests
-                        log_invalid_state(state=cs.XY(state().getX(), state().getY()), obstacle=o)
-                    else:  # happens in prod
-                        log_invalid_state(state=cs.XY(state.getX(), state.getY()), obstacle=o)
+                    # if isinstance(state, base.State):  # only happens in unit tests
+                    #     log_invalid_state(state=cs.XY(state().getX(), state().getY()), obstacle=o) # noqa
+                    # else:  # happens in prod
+                    #     log_invalid_state(state=cs.XY(state.getX(), state.getY()), obstacle=o)
                     return False
 
         return True


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
This is just a simple PR to comment out some code that is logging every time a state point is found to be invalid.
We definitely don't want this running all the time and we should just enable it when we need it for testing.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Local pathfinding pkg launches successfully and the invalid_states.log is not created

