### PR TITLE
Reverse the order of the waypoints in mock global path

### DIFF
--- a/src/local_pathfinding/local_pathfinding/node_mock_global_path.py
+++ b/src/local_pathfinding/local_pathfinding/node_mock_global_path.py
@@ -107,6 +107,7 @@ class MockGlobalPath(Node):
             # to ensure that node_navigate will still receive the waypoints
             # in the event that this node launches first and publishes the
             # mock global path once into the void
+            self.get_logger().debug("Publishing the global path unchanged")
             msg = self.global_path
 
         else:
@@ -164,6 +165,7 @@ class MockGlobalPath(Node):
 
         self.get_logger().debug(f"Publishing mock global path: {gp.path_to_dict(msg)}")
         self.global_path = msg
+        msg.waypoints = list(reversed(msg.waypoints))
         self.global_path_pub.publish(msg)
 
         # reset all checks for next function call


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
This PR is a resolution to a bug in `node_mock_global_path` where the interpolated global path was being published in the incorrect order. 

Expected Behavior:
The last waypoint in the published global path should be the closest global waypoint to Sailbot

Actual Buggy Behavior:
The first waypoint in the published global path was the closest global waypoint to Sailbot.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Ran local pathfinding with the visualizer and visually confirmed that the goal point is now within 30km of Sailbot as expected.