### PR TITLE
Timestamp change

### DIFF
--- a/src/network_systems/lib/sailbot_db/inc/sailbot_db.h
+++ b/src/network_systems/lib/sailbot_db/inc/sailbot_db.h
@@ -6,6 +6,7 @@
 #include <mongocxx/database.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/pool.hpp>
+#include <cstdint>
 
 #include "global_path.pb.h"
 #include "sensors.pb.h"
@@ -43,7 +44,7 @@ public:
         float       lat_;        // Transmission latitude
         float       lon_;        // Transmission longitude
         uint32_t    cep_;        // Transmission accuracy (km)
-        std::string timestamp_;  // Transmission time (<year - 2000>-<month>-<day> <hour>:<minute>:<second>)
+        int64_t timestamp_;  // Transmission time (Unix epoch time)
 
         /**
          * @brief overload stream operator
@@ -82,14 +83,6 @@ public:
     bool testConnection();
 
     /**
-         * @brief Get a properly formatted timestamp string
-         *
-         * @param tm standard C/C++ time structure
-         * @return tm converted to a timestamp string
-         */
-    static std::string mkTimestamp(const std::tm & tm);
-
-    /**
      * @brief Write new sensor data to the database
      *
      * @param sensors_pb Protobuf Sensors object
@@ -109,7 +102,7 @@ public:
      * @return true  if successful
      * @return false on failure
      */
-    bool storeNewGlobalPath(const Polaris::GlobalPath & global_pb, const std::string & timestamp);
+    bool storeNewGlobalPath(const Polaris::GlobalPath & global_pb, int64_t timestamp);
 
     /**
      * @brief Write global path data to the database
@@ -122,7 +115,7 @@ public:
      * @return false on failure
      */
     bool storeNewGlobalPath(
-      const Polaris::GlobalPath & global_path_pb, const std::string & timestamp, mongocxx::client & client);
+      const Polaris::GlobalPath & global_path_pb, int64_t timestamp, mongocxx::client & client);
 
     /**
      * @brief Write iridium response data to the database
@@ -130,14 +123,14 @@ public:
      * @param response       OK or FAILED
      * @param error          MO message error code
      * @param message        message given by rockblock server
-     * @param timestamp      transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+     * @param timestamp      transmission time in epoch time
 
      * @return true  if successful
      * @return false on failure
      */
     bool storeIridiumResponse(
       const std::string & response, const std::string & error, const std::string & message,
-      const std::string & timestamp);
+      int64_t timestamp);
 
     /**
      * @brief Write iridum response data to the database
@@ -145,7 +138,7 @@ public:
      * @param response       OK or FAILED
      * @param error          MO message error code
      * @param message        message given by rockblock server
-     * @param timestamp      transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+     * @param timestamp      transmission time epoch time in ms
      * @param client         mongocxx::client instance for the current thread
      *
      * @return true  if successful
@@ -153,7 +146,7 @@ public:
      */
     bool storeIridiumResponse(
       const std::string & response, const std::string & error, const std::string & message,
-      const std::string & timestamp, mongocxx::client & client);
+      int64_t timestamp, mongocxx::client & client);
 
 protected:
     const std::string               db_name_;  // Name of the database
@@ -166,75 +159,75 @@ private:
      * @brief Write GPS data to the database
      *
      * @param gps_pb    Protobuf GPS object
-     * @param timestamp transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+     * @param timestamp transmission time epoch time in ms
      * @param client    mongocxx::client instance for the current thread
      *
      * @return true  if successful
      * @return false on failure
      */
-    bool storeGps(const Polaris::Sensors::Gps & gps_pb, const std::string & timestamp, mongocxx::client & client);
+    bool storeGps(const Polaris::Sensors::Gps & gps_pb, int64_t timestamp, mongocxx::client & client);
 
     /**
      * @brief Write AIS data to the database
      *
      * @param ais_ships_pb Protobuf list of AIS objects, where the size of the list is the number of ships
-     * @param timestamp    transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+     * @param timestamp    transmission time epoch time in ms
      * @param client       mongocxx::client instance for the current thread
 
      * @return true  if successful
      * @return false on failure
      */
     bool storeAis(
-      const ProtoList<Polaris::Sensors::Ais> & ais_ships_pb, const std::string & timestamp, mongocxx::client & client);
+      const ProtoList<Polaris::Sensors::Ais> & ais_ships_pb, int64_t timestamp, mongocxx::client & client);
 
     /**
      * @brief Write path sensor data to the database
      *
      * @param generic_pb Protobuf list of path sensor objects, where the size of the list is the number of path sensors
-     * @param timestamp  transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+     * @param timestamp  transmission time epoch time in ms
      * @param client     mongocxx::client instance for the current thread
 
      * @return true  if successful
      * @return false on failure
      */
     bool storePathSensors(
-      const Polaris::Sensors::Path & local_path_pb, const std::string & timestamp, mongocxx::client & client);
+      const Polaris::Sensors::Path & local_path_pb, int64_t timestamp, mongocxx::client & client);
 
     /**
     * @brief Adds generic sensors to the database
     *
     * @param generic_pb Protobuf list of generic sensor objects, where the size of the list is the number of sensors
-    * @param timestamp  transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+    * @param timestamp  transmission time epoch time in ms
     * @param client     mongocxx::client instance for the current thread
     *
     * @return True if sensor is added, false otherwise
     */
     bool storeGenericSensors(
-      const ProtoList<Polaris::Sensors::Generic> & generic_pb, const std::string & timestamp,
+      const ProtoList<Polaris::Sensors::Generic> & generic_pb, int64_t timestamp,
       mongocxx::client & client);
 
     /**
     * @brief Adds a battery sensors to the database
     *
     * @param generic_pb Protobuf list of battery objects
-    * @param timestamp  transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+    * @param timestamp  transmission time epoch time in ms
     * @param client     mongocxx::client instance for the current thread
     *
     * @return True if sensor is added, false otherwise
     */
     bool storeBatteries(
-      const ProtoList<Polaris::Sensors::Battery> & battery_pb, const std::string & timestamp,
+      const ProtoList<Polaris::Sensors::Battery> & battery_pb, int64_t timestamp,
       mongocxx::client & client);
 
     /**
     * @brief Adds a wind sensor to the database flow
     *
     * @param generic_pb Protobuf list of wind sensor objects
-    * @param timestamp  transmission time <year - 2000>-<month>-<day> <hour>:<minute>:<second>
+    * @param timestamp  transmission time epoch time in ms
     * @param client     mongocxx::client instance for the current thread
     *
     * @return True if sensor is added, false otherwise
     */
     bool storeWindSensors(
-      const ProtoList<Polaris::Sensors::Wind> & wind_pb, const std::string & timestamp, mongocxx::client & client);
+      const ProtoList<Polaris::Sensors::Wind> & wind_pb, int64_t timestamp, mongocxx::client & client);
 };

--- a/src/network_systems/lib/sailbot_db/inc/util_db.h
+++ b/src/network_systems/lib/sailbot_db/inc/util_db.h
@@ -2,6 +2,7 @@
 
 #include <random>
 #include <span>
+#include <cstdint>
 
 #include "sailbot_db.h"
 #include "sensors.pb.h"
@@ -40,7 +41,7 @@ public:
     /**
      * @return timestamp for the current time
      */
-    static std::tm getTimestamp();
+    static int64_t getTimestamp();
 
     /**
     * @brief Generate random sensors and Iridium msg info
@@ -48,7 +49,7 @@ public:
     * @param tm Timestamp returned by getTimestamp() (with any modifications made to it)
     * @return std::pair<Sensors, SailbotDB::RcvdMsgInfo>
     */
-    std::pair<Polaris::Sensors, SailbotDB::RcvdMsgInfo> genRandData(const std::tm & tm);
+    std::pair<Polaris::Sensors, SailbotDB::RcvdMsgInfo> genRandData(int64_t timestamp);
 
     /**
     * @brief Generate random global path data
@@ -56,7 +57,7 @@ public:
     * @param tm Timestamp returned by getTimestamp() (with any modifications made to it)
     * @return std::pair<Polaris::GlobalPath, std::string>
     */
-    std::pair<Polaris::GlobalPath, std::string> genGlobalData(const std::tm & tm);
+    std::pair<Polaris::GlobalPath, int64_t> genGlobalData(int64_t timestamp);
 
     /**
     * @brief Query the database and check that the sensor and message are correct
@@ -74,7 +75,7 @@ public:
     * @param expected_timestamp
     */
     bool verifyDBWrite_GlobalPath(
-      std::span<Polaris::GlobalPath> expected_globalpath, std::span<std::string> expected_timestamp);
+      std::span<Polaris::GlobalPath> expected_globalpath, std::span<int64_t> expected_timestamp);
 
     /**
     * @brief Query the database and check that the Iridium response, error code, message, and timestamp are correct
@@ -86,7 +87,7 @@ public:
     */
     bool verifyDBWrite_IridiumResponse(
       std::span<std::string> expected_response, std::span<std::string> expected_error,
-      std::span<std::string> expected_message, std::span<std::string> expected_timestamp);
+      std::span<std::string> expected_message, std::span<int64_t> expected_timestamp);
 
     /**
      * @brief Dump and check all sensors and timestamps from the database
@@ -95,7 +96,7 @@ public:
      * @param expected_num_docs Expected number of documents. tracker is updated if there's a mismatch
      * @return std::pair{Vector of dumped Sensors, Vector of dumped timestamps}
      */
-    std::pair<std::vector<Polaris::Sensors>, std::vector<std::string>> dumpSensors(
+    std::pair<std::vector<Polaris::Sensors>, std::vector<int64_t>> dumpSensors(
       utils::FailTracker & tracker, size_t expected_num_docs = 1);
 
     /**
@@ -105,7 +106,7 @@ public:
      * @param expected_num_docs Expected number of documents. tracker is updated if there's a mismatch
      * @return std::pair{Vector of dumped Global Paths, Vector of dumped timestamps}
      */
-    std::pair<std::vector<Polaris::GlobalPath>, std::vector<std::string>> dumpGlobalpath(
+    std::pair<std::vector<Polaris::GlobalPath>, std::vector<int64_t>> dumpGlobalpath(
       utils::FailTracker & tracker, size_t expected_num_docs = 1);
 
     /**
@@ -115,7 +116,7 @@ public:
      * @param expected_num_docs Expected number of documents. tracker is updated if there's a mismatch
      * @return std::tuple{Vector of dumped responses, Vector of dumped error codes, Vector of dumped messages, Vector of dumped timestamps}
      */
-    std::tuple<std::vector<std::string>, std::vector<std::string>, std::vector<std::string>, std::vector<std::string>>
+    std::tuple<std::vector<std::string>, std::vector<std::string>, std::vector<std::string>, std::vector<int64_t>>
     dumpIridiumResponse(utils::FailTracker & tracker, size_t expected_num_docs = 1);
 
 private:

--- a/src/network_systems/lib/sailbot_db/src/sailbot_db.cpp
+++ b/src/network_systems/lib/sailbot_db/src/sailbot_db.cpp
@@ -51,20 +51,6 @@ const std::string & SailbotDB::MONGODB_CONN_STR()
     return conn_str;
 }
 
-std::string SailbotDB::mkTimestamp(const std::tm & tm)
-{
-    constexpr int     YEAR_OFFSET  = 1900;  // tm_year is years since 1900
-    constexpr int     YEAR_MODULUS = 100;   // used to extract the last two digits of the year
-    std::stringstream tm_ss;
-    tm_ss << std::setfill('0') << std::setw(2)
-          << (tm.tm_year + YEAR_OFFSET) % YEAR_MODULUS  // format last 2 digits of year (e.g., 2025 → 25)
-          << "-" << std::setfill('0') << std::setw(2) << (tm.tm_mon + 1)  // months are 0-based (0 = January)
-          << "-" << std::setfill('0') << std::setw(2) << tm.tm_mday << " " << std::setfill('0') << std::setw(2)  // hour
-          << tm.tm_hour << ":" << std::setfill('0') << std::setw(2) << tm.tm_min << ":" << std::setfill('0')  // minute
-          << std::setw(2) << tm.tm_sec;                                                                       // second
-    return tm_ss.str();
-}
-
 SailbotDB::SailbotDB(const std::string & db_name, const std::string & mongodb_conn_str) : db_name_(db_name)
 {
     mongocxx::uri uri = mongocxx::uri{mongodb_conn_str};
@@ -91,7 +77,7 @@ bool SailbotDB::testConnection()
 bool SailbotDB::storeNewSensors(const Sensors & sensors_pb, RcvdMsgInfo new_info)
 {
     // Only using timestamp info for now, may use other fields in the future
-    const std::string &   timestamp = new_info.timestamp_;
+    int64_t timestamp = new_info.timestamp_;
     mongocxx::pool::entry entry     = pool_->acquire();
     return storeGps(sensors_pb.gps(), timestamp, *entry) && storeAis(sensors_pb.ais_ships(), timestamp, *entry) &&
            storeGenericSensors(sensors_pb.data_sensors(), timestamp, *entry) &&
@@ -102,14 +88,14 @@ bool SailbotDB::storeNewSensors(const Sensors & sensors_pb, RcvdMsgInfo new_info
 
 // END PUBLIC
 
-bool SailbotDB::storeNewGlobalPath(const GlobalPath & global_pb, const std::string & timestamp)
+bool SailbotDB::storeNewGlobalPath(const GlobalPath & global_pb, int64_t timestamp)
 {
     mongocxx::pool::entry entry = pool_->acquire();
     return storeNewGlobalPath(global_pb, timestamp, *entry);
 }
 
 bool SailbotDB::storeIridiumResponse(
-  const std::string & response, const std::string & error, const std::string & message, const std::string & timestamp)
+  const std::string & response, const std::string & error, const std::string & message, int64_t timestamp)
 {
     mongocxx::pool::entry entry = pool_->acquire();
     return storeIridiumResponse(response, error, message, timestamp, *entry);
@@ -117,7 +103,7 @@ bool SailbotDB::storeIridiumResponse(
 
 // PRIVATE
 
-bool SailbotDB::storeGps(const Sensors::Gps & gps_pb, const std::string & timestamp, mongocxx::client & client)
+bool SailbotDB::storeGps(const Sensors::Gps & gps_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database   db       = client[db_name_];
     mongocxx::collection gps_coll = db[COLLECTION_GPS];
@@ -129,7 +115,7 @@ bool SailbotDB::storeGps(const Sensors::Gps & gps_pb, const std::string & timest
 }
 
 bool SailbotDB::storeAis(
-  const ProtoList<Sensors::Ais> & ais_ships_pb, const std::string & timestamp, mongocxx::client & client)
+  const ProtoList<Sensors::Ais> & ais_ships_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database   db       = client[db_name_];
     mongocxx::collection ais_coll = db[COLLECTION_AIS_SHIPS];
@@ -148,7 +134,7 @@ bool SailbotDB::storeAis(
 }
 
 bool SailbotDB::storeGenericSensors(
-  const ProtoList<Sensors::Generic> & generic_pb, const std::string & timestamp, mongocxx::client & client)
+  const ProtoList<Sensors::Generic> & generic_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database   db           = client[db_name_];
     mongocxx::collection generic_coll = db[COLLECTION_DATA_SENSORS];
@@ -163,7 +149,7 @@ bool SailbotDB::storeGenericSensors(
 }
 
 bool SailbotDB::storeBatteries(
-  const ProtoList<Sensors::Battery> & battery_pb, const std::string & timestamp, mongocxx::client & client)
+  const ProtoList<Sensors::Battery> & battery_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database   db             = client[db_name_];
     mongocxx::collection batteries_coll = db[COLLECTION_BATTERIES];
@@ -178,7 +164,7 @@ bool SailbotDB::storeBatteries(
 }
 
 bool SailbotDB::storeWindSensors(
-  const ProtoList<Sensors::Wind> & wind_pb, const std::string & timestamp, mongocxx::client & client)
+  const ProtoList<Sensors::Wind> & wind_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database   db        = client[db_name_];
     mongocxx::collection wind_coll = db[COLLECTION_WIND_SENSORS];
@@ -193,7 +179,7 @@ bool SailbotDB::storeWindSensors(
 }
 
 bool SailbotDB::storePathSensors(
-  const Sensors::Path & local_path_pb, const std::string & timestamp, mongocxx::client & client)
+  const Sensors::Path & local_path_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database           db              = client[db_name_];
     mongocxx::collection         local_path_coll = db[COLLECTION_LOCAL_PATH];
@@ -209,7 +195,7 @@ bool SailbotDB::storePathSensors(
 }
 
 bool SailbotDB::storeNewGlobalPath(
-  const Polaris::GlobalPath & global_path_pb, const std::string & timestamp, mongocxx::client & client)
+  const Polaris::GlobalPath & global_path_pb, int64_t timestamp, mongocxx::client & client)
 {
     mongocxx::database           db               = client[db_name_];
     mongocxx::collection         global_path_coll = db[COLLECTION_GLOBAL_PATH];
@@ -226,7 +212,7 @@ bool SailbotDB::storeNewGlobalPath(
 }
 
 bool SailbotDB::storeIridiumResponse(
-  const std::string & response, const std::string & error, const std::string & message, const std::string & timestamp,
+  const std::string & response, const std::string & error, const std::string & message, int64_t timestamp,
   mongocxx::client & client)
 {
     mongocxx::database   db                    = client[db_name_];

--- a/src/network_systems/projects/remote_transceiver/inc/remote_transceiver.h
+++ b/src/network_systems/projects/remote_transceiver/inc/remote_transceiver.h
@@ -48,7 +48,7 @@ struct MOMsgParams
         uint64_t    imei_;           // Rockblock IMEI
         uint32_t    serial_;         // Rockblock serial #. Don't know the max size
         uint16_t    momsn_;          // # msgs sent from the Rockblock [0, 65535]
-        std::string transmit_time_;  // UTC date and time. Ex: "21-10-31 10:41:50"
+        int64_t transmit_time_;      // Epoch Time in ms
         float       lat_;            // transmitted from this latitude
         float       lon_;            // transmitted from this longitude
         uint32_t    cep_;            // estimate of the accuracy (in km) of the reported lat_ lon_ fields


### PR DESCRIPTION
Updated timestamp output to use the Unix epoch time instead of the previous format being a string. Makes it easier to use in Website and also saves memory at the same time. 

Are there any tests to check if our changes are correct?

