### PR TITLE
Fixed the lack of true wind update in mock_gps

### DIFF
--- a/src/local_pathfinding/.gitignore
+++ b/src/local_pathfinding/.gitignore
@@ -17,3 +17,6 @@ log/*
 
 
 *.log
+
+# Generated ros2 parameters through initiation and simulation
+src/local_pathfinding/local_pathfinding/mock_nodes/wind_params.yaml

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
@@ -5,16 +5,16 @@ Mock class for the GPS. Publishes basic GPS data to the ROS network.
 import math
 from typing import List
 
-import custom_interfaces.msg as ci
 import rclpy
 from geopy.distance import great_circle
 from rcl_interfaces.msg import SetParametersResult
 from rclpy.node import Node
 from rclpy.parameter import Parameter
+from test_plans.test_plan import TestPlan
 
+import custom_interfaces.msg as ci
 import local_pathfinding.coord_systems as cs
 from local_pathfinding.ompl_objectives import TimeObjective
-from test_plans.test_plan import TestPlan
 
 SECONDS_PER_HOUR = 3600
 
@@ -83,6 +83,9 @@ class MockGPS(Node):
         self._mock_gps_timer = self.create_timer(
             timer_period_sec=self.pub_period_sec, callback=self.mock_gps_callback
         )
+
+        # Parameter Event Handler (Parameters can change over the life of the simulation)
+        self.add_on_set_parameters_callback(self._on_set_parameters)
 
     def mock_gps_callback(self) -> None:
         """Updates boat speed based on current heading and true wind.

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_wind_sensor.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_wind_sensor.py
@@ -31,14 +31,14 @@ Setting True Wind Parameters:
 
 from typing import List
 
-import custom_interfaces.msg as ci
 import rclpy
 from rcl_interfaces.msg import SetParametersResult
 from rclpy.node import Node
 from rclpy.parameter import Parameter
-
-import local_pathfinding.wind_coord_systems as wcs
 from test_plans.test_plan import TestPlan
+
+import custom_interfaces.msg as ci
+import local_pathfinding.wind_coord_systems as wcs
 
 
 class MockWindSensor(Node):
@@ -76,6 +76,7 @@ class MockWindSensor(Node):
             msg_type=ci.GPS, topic="gps", callback=self.gps_callback, qos_profile=10
         )
 
+        # Parameter Event Handler (Parameters can change over the life of the simulation)
         self.add_on_set_parameters_callback(self._on_set_parameters)
 
     def mock_wind_sensor_callback(self):


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->

@raghumanimehta found that the boat speed was never 0 kmph. This was caused by a small bug where the mock GPS node did not have the `add_on_set_parameters_callback` but had the callback function `_on_set_parameters`. In comparison, the mock wind sensor had the `add_on_set_parameters_callback` and was functioning correctly. This kind of discrepancy may be due to an issue during merging (a guess). 

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Use the table in `ompl_objectives.py` and check if the boat speed is 0 and is close to the speeds based on its sailing angle and true wind direction.
