### PR TITLE
#908: Connecting segment deviation to update_if_needed 

### DIFF
--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -526,6 +526,8 @@ class LocalPath:
             IndexError: If the target waypoint is reached and no next local waypoint exists.
         """
         self._target_lp_wp_index = target_lp_wp_index
+        boat_lat_lon = None
+
         new_aw = Wind(
             inputs.filtered_wind_sensor.speed.speed,
             inputs.filtered_wind_sensor.direction,
@@ -548,11 +550,11 @@ class LocalPath:
                 self._logger.warn(e)
                 boat_lat_lon = self.state.position  # type: ignore
 
-            must_change_reason = self.must_change_path(
-                received_new_global_waypoint,
-                boat_lat_lon,
-                new_aw,
-            )
+        must_change_reason = self.must_change_path(
+            received_new_global_waypoint,
+            boat_lat_lon,
+            new_aw,
+        )
 
         if must_change_reason.should_change_path:
             tries = 0

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -433,7 +433,10 @@ class LocalPath:
         return distance_to_segment_km > max_deviation_km
 
     def must_change_path(
-        self, received_new_global_waypoint: bool, new_aw: Optional[Wind] = None
+        self,
+        received_new_global_waypoint: bool,
+        boat_lat_lon: Optional[ci.HelperLatLon] = None,
+        new_aw: Optional[Wind] = None,
     ) -> MustChangeReason:
         """Check if the path must be changed.
 
@@ -465,12 +468,18 @@ class LocalPath:
             return MustChangeReason(
                 True,
                 f"Target waypoint index too low: {self._target_lp_wp_index}"
-                )
+            )
         if self._target_lp_wp_index >= len(self.path.waypoints):
             return MustChangeReason(
                 True,
                 f"Target waypoint index out of bounds: {self._target_lp_wp_index} >= {len(self.path.waypoints)}",  # noqa
             )
+        if boat_lat_lon is not None and self.exceeded_segment_deviation(
+            self.path,
+            self._target_lp_wp_index,
+            boat_lat_lon,
+        ):
+            return MustChangeReason(True, "Boat deviated from path segment")
 
         return MustChangeReason(
             False,
@@ -539,7 +548,11 @@ class LocalPath:
                 self._logger.warn(e)
                 boat_lat_lon = self.state.position  # type: ignore
 
-        must_change_reason = self.must_change_path(received_new_global_waypoint, new_aw)
+            must_change_reason = self.must_change_path(
+                received_new_global_waypoint,
+                boat_lat_lon,
+                new_aw,
+            )
 
         if must_change_reason.should_change_path:
             tries = 0

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -390,8 +390,8 @@ class LocalPath:
             valid preceding/target waypoint is required to define the segment.
         """
         if target_lp_wp_index == 0 or target_lp_wp_index >= len(path.waypoints):
-            self._logger.warn("Target waypoint out of bounds, must be in range [1, len(waypoints)")
-            raise IndexError("Target Waypoint out of bounds, must be in range [1, len(waypoints)")
+            self._logger.warn("Target waypoint out of bounds, must be in range [1, len(waypoints))")  # noqa
+            raise IndexError("Target waypoint out of bounds, must be in range [1, len(waypoints))")
 
         prev_wp = path.waypoints[target_lp_wp_index - 1]
         target_wp = path.waypoints[target_lp_wp_index]

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -430,7 +430,15 @@ class LocalPath:
         rejection_vector = boat_vector - projection_vector
         distance_to_segment_km = np.linalg.norm(rejection_vector)
 
-        return distance_to_segment_km > max_deviation_km
+        segment_exceeded = distance_to_segment_km > max_deviation_km
+        if segment_exceeded:
+            self._logger.info(
+                "Boat deviated from path segment: "
+                f"distance {distance_to_segment_km:.2f} km, "
+                f"max deviation {max_deviation_km:.2f} km"
+            )
+
+        return segment_exceeded
 
     def must_change_path(
         self,

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -445,6 +445,28 @@ class LocalPath:
     ) -> MustChangeReason:
         """Check if the path must be changed.
 
+        Evaluates a prioritized set of conditions and returns a `MustChangeReason` indicating
+        whether a path change is required and a reason.
+
+        Priority of checks (first matching condition wins):
+        - Receipt of a new global waypoint (always requires a new local path)
+        - Missing OMPL path, LocalPathState, or local path
+        - Current path intersects a collision zone
+        - Path time-to-live (TTL) has expired
+        - Significant wind change between the rolling wind average and the wind used to
+          generate the current path (only evaluated when the rolling average is available
+          and the current path was not generated from a single apparent-wind point)
+        - Invalid target local waypoint index (too low or beyond available waypoints)
+        - Boat has deviated from the current path segment beyond the allowed threshold
+
+        Args:
+            received_new_global_waypoint (bool): True when the global path advanced to a
+                new waypoint and a local-path regeneration should be triggered.
+            boat_lat_lon (Optional[ci.HelperLatLon], optional): Current boat position used to
+                evaluate segment deviation. If None, deviation is not evaluated.
+            new_aw (Optional[Wind], optional): The most recent apparent wind reading. This
+                value is used to update wind history before evaluating wind-based switching.
+
         Returns:
             MustChangeReason
         """

--- a/src/local_pathfinding/test/test_local_path.py
+++ b/src/local_pathfinding/test/test_local_path.py
@@ -1517,6 +1517,47 @@ def test_update_if_needed_regenerates_path_for_significant_wind_change(
     ompl_path_cls.assert_called_once()
 
 
+def test_update_if_needed_regenerates_path_when_segment_deviation_exceeded(
+    basic_local_path_state,
+):
+    local_path, old_path, old_ompl_path = create_initialized_local_path_for_update_if_needed(
+        basic_local_path_state
+    )
+    inputs = create_update_if_needed_inputs()
+    new_path = Path(
+        waypoints=[
+            HelperLatLon(latitude=1.0, longitude=1.0),
+            HelperLatLon(latitude=0.0, longitude=0.0),
+        ]
+    )
+    new_ompl_path = create_solved_ompl_path(new_path)
+
+    with (
+        mock.patch.object(local_path, "in_collision_zone", return_value=False),
+        mock.patch.object(local_path, "is_path_expired", return_value=False),
+        mock.patch.object(
+            local_path,
+            "exceeded_segment_deviation",
+            return_value=True,
+        ) as exceeded_segment_deviation,
+        mock.patch.object(lp, "OMPLPath", return_value=new_ompl_path) as ompl_path_cls,
+    ):
+        desired_heading, new_target_lp_wp_index = local_path.update_if_needed(
+            inputs=inputs,
+            target_lp_wp_index=1,
+            received_new_global_waypoint=False,
+        )
+
+    assert desired_heading == pytest.approx(90.0, abs=3e-1)
+    assert new_target_lp_wp_index == 1
+    assert local_path._ompl_path is new_ompl_path
+    assert local_path.path is new_path
+    assert local_path._ompl_path is not old_ompl_path
+    local_path._logger.info.assert_any_call("Updating local path: Boat deviated from path segment")
+    exceeded_segment_deviation.assert_called_once_with(old_path, 1, inputs.gps.lat_lon)
+    ompl_path_cls.assert_called_once()
+
+
 def test_update_if_needed_raises_when_path_generation_exceeds_retries():
     mock_parent_logger = mock.Mock()
     mock_parent_logger.get_child.return_value = mock.Mock()

--- a/src/local_pathfinding/test/test_local_path.py
+++ b/src/local_pathfinding/test/test_local_path.py
@@ -1558,6 +1558,39 @@ def test_update_if_needed_regenerates_path_when_segment_deviation_exceeded(
     ompl_path_cls.assert_called_once()
 
 
+def test_update_if_needed_reuses_path_when_boat_not_deviated(
+    basic_local_path_state,
+):
+    local_path, old_path, old_ompl_path = create_initialized_local_path_for_update_if_needed(
+        basic_local_path_state
+    )
+    inputs = create_update_if_needed_inputs()
+
+    with (
+        mock.patch.object(local_path, "in_collision_zone", return_value=False),
+        mock.patch.object(local_path, "is_path_expired", return_value=False),
+        mock.patch.object(
+            local_path,
+            "exceeded_segment_deviation",
+            return_value=False,
+        ) as exceeded_segment_deviation,
+        mock.patch.object(lp, "OMPLPath") as ompl_path_cls,
+    ):
+        desired_heading, new_target_lp_wp_index = local_path.update_if_needed(
+            inputs=inputs,
+            target_lp_wp_index=1,
+            received_new_global_waypoint=False,
+        )
+
+    assert desired_heading == pytest.approx(90.0, abs=3e-1)
+    assert new_target_lp_wp_index == 1
+    assert local_path._ompl_path is old_ompl_path
+    assert local_path.path is old_path
+    exceeded_segment_deviation.assert_called_once_with(old_path, 1, inputs.gps.lat_lon)
+    ompl_path_cls.assert_not_called()
+    local_path._logger.info.assert_any_call("Reusing local path: Path is valid, no change needed")
+
+
 def test_update_if_needed_raises_when_path_generation_exceeds_retries():
     mock_parent_logger = mock.Mock()
     mock_parent_logger.get_child.return_value = mock.Mock()


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #908 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->

### Changes Made
- Updated `must_change_path` to accept `boat_lat_lon`
- Integrated `exceeded_segment_deviation` check after the index out of bounds (too low/high) checks, therefore no issues should be raised from `exceeded_segment_deviation` 
- If `boat_lat_lon` is not provided (defaults to None), the deviation check is skipped and no path change is triggered from this condition
- `exceeded_segment_deviation` now logs when deviation is exceeded, including the current distance and max threshold in km

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- Added test verifying that the path is regenerated when deviation exceeds thresholds (`exceeded_segment_deviation` returns `True`)
- Added test verifying that the path remains unchanged when deviation is within acceptable limits (`exceeded_segment_deviation` returns `False`)
- Verified that the path is regenerated when the boat exceeds the deviation threshold, confirmed via logs by temporarily lowering the threshold to trigger the check

