### PR TITLE
CAN hotfix for on water test

### DIFF
--- a/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
@@ -629,12 +629,12 @@ void AISShips::checkBounds() const
         std::string err_msg = err.value();
         throw std::out_of_range("ROT is out of bounds!\n" + debugStr() + "\n" + err_msg);
     }
-    err = utils::isOutOfBounds<float>(width_, SHIP_DIMENSION_LBND, SHIP_DIMENSION_UBND);
+    err = utils::isOutOfBounds<float>(width_, SHIP_DIMENSION_LBND - 1, SHIP_DIMENSION_UBND);
     if (err) {
         std::string err_msg = err.value();
         throw std::out_of_range("Width is out of bounds!\n" + debugStr() + "\n" + err_msg);
     }
-    err = utils::isOutOfBounds<float>(length_, SHIP_DIMENSION_LBND, SHIP_DIMENSION_UBND);
+    err = utils::isOutOfBounds<float>(length_, SHIP_DIMENSION_LBND - 1, SHIP_DIMENSION_UBND);
     if (err) {
         std::string err_msg = err.value();
         throw std::out_of_range("Length is out of bounds!\n" + debugStr() + "\n" + err_msg);

--- a/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
@@ -27,8 +27,11 @@ void CanTransceiver::onNewCanData(const CanFrame & frame) const
         return;
     }
     CanId id{frame.can_id};
+    // TODO: REMOVE PRESSURE SENSORS PROPERLY (hotfix for on water test)
 
-    if (id >= CanId::DEBUG_START && id <= CanId::DEBUG_END) {
+    if (
+      (id >= CanId::DEBUG_START && id <= CanId::DEBUG_END) ||
+      (id >= CanId::PRESSURE_SENSOR_START && id <= CanId::PRESSURE_SENSOR_END)) {
         // ELEC debug frame, do nothing
         return;
     }

--- a/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
@@ -27,7 +27,7 @@ void CanTransceiver::onNewCanData(const CanFrame & frame) const
         return;
     }
     CanId id{frame.can_id};
-    // TODO: REMOVE PRESSURE SENSORS PROPERLY (hotfix for on water test)
+    // REMOVE PRESSURE SENSORS PROPERLY (hotfix for on water test)
 
     if (
       (id >= CanId::DEBUG_START && id <= CanId::DEBUG_END) ||

--- a/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
@@ -731,8 +731,8 @@ TEST_F(TestCanFrameParser, TestAISShipsInvalid)
     constexpr std::array<float, 2>  invalid_cogs{-361, 361};
     constexpr std::array<float, 2>  invalid_sogs{SOG_SPEED_LBND - 1, SOG_SPEED_UBND + 1};
     constexpr std::array<int8_t, 2> invalid_rots{ROT_LBND - 1, ROT_UBND + 1};
-    constexpr std::array<float, 2>  invalid_widths{SHIP_DIMENSION_LBND - 1, SHIP_DIMENSION_UBND + 1};
-    constexpr std::array<float, 2>  invalid_lengths{SHIP_DIMENSION_LBND - 1, SHIP_DIMENSION_UBND + 1};
+    constexpr std::array<float, 2>  invalid_widths{SHIP_DIMENSION_LBND - 2, SHIP_DIMENSION_UBND + 1};
+    constexpr std::array<float, 2>  invalid_lengths{SHIP_DIMENSION_LBND - 2, SHIP_DIMENSION_UBND + 1};
 
     CAN_FP::CanId      valid_id = CAN_FP::CanId::SAIL_AIS;
     msg::HelperAISShip msg;

--- a/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
@@ -1599,31 +1599,31 @@ TEST_F(TestCanTransceiver, TestNewDataSalinityValid)
  * @brief Test that callback can be properly registered and invoked on PRESSURE CanIds
  *
  */
-TEST_F(TestCanTransceiver, TestNewDataPressureValid)
-{
-    using underlying = std::underlying_type_t<CAN_FP::CanId>;
-    for (underlying id = static_cast<underlying>(CAN_FP::CanId::PRESSURE_SENSOR_START);
-         id <= static_cast<underlying>(CAN_FP::CanId::PRESSURE_SENSOR_END); ++id) {
-        CAN_FP::CanId sensor_id = static_cast<CAN_FP::CanId>(id);
-        // for (CAN_FP::CanId id = CAN_FP::CanId::TEMP_SENSOR_START; id <= CAN_FP::CanId::TEMP_SENSOR_END; id++) {
-        volatile bool                         is_cb_called = false;
-        std::function<void(CAN_FP::CanFrame)> test_cb      = [&is_cb_called](CAN_FP::CanFrame /*unused*/) {
-            is_cb_called = true;
-        };
-        canbus_t_->registerCanCbs({{
-          std::make_pair(sensor_id, test_cb),
-        }});
+// TEST_F(TestCanTransceiver, TestNewDataPressureValid)
+// {
+//     using underlying = std::underlying_type_t<CAN_FP::CanId>;
+//     for (underlying id = static_cast<underlying>(CAN_FP::CanId::PRESSURE_SENSOR_START);
+//          id <= static_cast<underlying>(CAN_FP::CanId::PRESSURE_SENSOR_END); ++id) {
+//         CAN_FP::CanId sensor_id = static_cast<CAN_FP::CanId>(id);
+//         // for (CAN_FP::CanId id = CAN_FP::CanId::TEMP_SENSOR_START; id <= CAN_FP::CanId::TEMP_SENSOR_END; id++) {
+//         volatile bool                         is_cb_called = false;
+//         std::function<void(CAN_FP::CanFrame)> test_cb      = [&is_cb_called](CAN_FP::CanFrame /*unused*/) {
+//             is_cb_called = true;
+//         };
+//         canbus_t_->registerCanCbs({{
+//           std::make_pair(sensor_id, test_cb),
+//         }});
 
-        // just need a valid and matching ID for this test
-        CAN_FP::CanFrame dummy_frame{.can_id = static_cast<canid_t>(sensor_id)};
+//         // just need a valid and matching ID for this test
+//         CAN_FP::CanFrame dummy_frame{.can_id = static_cast<canid_t>(sensor_id)};
 
-        canbus_t_->send(dummy_frame);
+//         canbus_t_->send(dummy_frame);
 
-        std::this_thread::sleep_for(SLEEP_TIME);
+//         std::this_thread::sleep_for(SLEEP_TIME);
 
-        EXPECT_TRUE(is_cb_called);
-    }
-}
+//         EXPECT_TRUE(is_cb_called);
+//     }
+// }
 
 /**
  * @brief Test that the CanTransceiver ignores IDs that we don't register callbacks for


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- bandaid fix for CAN frame id filtering; need to remove pressure sensors later
- allow AIS ship sizes of 0 dimensions
