### PR TITLE
Add Configurable Global Config Files

### DIFF
--- a/src/boat_simulator/launch/main_launch.py
+++ b/src/boat_simulator/launch/main_launch.py
@@ -111,9 +111,13 @@ def get_physics_engine_description(context: LaunchContext) -> Node:
         Node: The node object that launches the physics engine node.
     """
     node_name = "physics_engine_node"
+    config_path = LaunchConfiguration("config").perform(context)
     test_plan = LaunchConfiguration("test_plan").perform(context)
+    # An empty test_plan arg means "use the test_plan from the config file".
+    if not test_plan:
+        test_plan = get_test_plan_from_config(config_path)
     ros_parameters = [
-        LaunchConfiguration("config").perform(context),
+        config_path,
         get_sim_gps_origin_parameters(test_plan),
     ]
     ros_arguments: List[SomeSubstitutionsType] = [
@@ -152,6 +156,23 @@ def get_sim_gps_origin_parameters(test_plan: str) -> dict:
     except Exception as exc:
         raise RuntimeError(
             f"Failed to load simulator GPS origin from test plan '{test_plan_path}': {exc}"
+        ) from exc
+
+
+def get_test_plan_from_config(config_path: str) -> str:
+    """Read the test_plan parameter from the global config file.
+
+    Used when the test_plan launch argument is empty so the simulator falls back to the value
+    specified in the config file (under the `/**` wildcard's ros__parameters).
+    """
+    try:
+        with open(config_path, "r") as file:
+            data = yaml.safe_load(file)
+        return data["/**"]["ros__parameters"]["test_plan"]
+    except Exception as exc:
+        raise RuntimeError(
+            f"test_plan launch argument is empty and no test_plan could be read from the config"
+            f" file '{config_path}': {exc}"
         ) from exc
 
 

--- a/src/global_launch/README.md
+++ b/src/global_launch/README.md
@@ -13,6 +13,34 @@
     - `production`: `network_systems` provides the `filtered_wind_sensor` and `gps` data from the real sensors over the network, and `controller` relies on `network_systems`' control publishers/subscribers to drive the boat. Used for on-water operation.
     - `sim`: launches the additional `boat_simulator` package, which simulates the boat (physics, GPS, wind sensors) to run the full software stack end-to-end against a simulated boat on pathfinding's visualizer.
   <!-- markdownlint-enable MD013 -->
+- To select the config file, use the `config` launch argument (e.g. `config:=globals.yaml`).
+  <!-- markdownlint-disable MD013 -->
+    - This is the ROS parameter config filename located in `src/global_launch/config`, and it controls the ROS parameters passed into the ROS nodes. There are three different scenario configurations:
+    - `globals.yaml` (default): A default ROS parameter setting.
+    - `on_water_globals.yaml`: For on-water testing across `production`, `development`, and `sim`. This must be used when doing on-water testing.
+    - `launch_globals.yaml`: For launch in the open ocean for `production`, but can also run in `development` and `sim` for testing.
+  <!-- markdownlint-enable MD013 -->
+
+## Example launch commands
+
+<!-- markdownlint-disable MD013 -->
+- Default development run (mock data, no recording):
+  `ros2 launch global_launch main_launch.py`
+- Development run with debug logging:
+  `ros2 launch global_launch main_launch.py mode:=development log_level:=debug`
+- Simulation run against the boat simulator:
+  `ros2 launch global_launch main_launch.py mode:=sim config:=globals.yaml`
+- On-water testing (must use the on-water config):
+  `ros2 launch global_launch main_launch.py mode:=production config:=on_water_globals.yaml record:=true`
+- Open-ocean launch run for production:
+  `ros2 launch global_launch main_launch.py mode:=production config:=launch_globals.yaml record:=true`
+- Recording a rosbag to a custom folder:
+  `ros2 launch global_launch main_launch.py record:=true save_path:=notebooks/test_recordings`
+- Full on-water run with a timestamped log file with ros2bag:
+  `ros2 launch global_launch main_launch.py record:=true mode:=production config:=on_water_globals.yaml 2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt`
+- Full Launch run with a timestamped log file with ros2bag:
+  `ros2 launch global_launch main_launch.py record:=true mode:=production config:=launch_globals.yaml 2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt`
+<!-- markdownlint-enable MD013 -->
 
 ## Recording a rosbag file for future analysis
 
@@ -31,4 +59,5 @@
 `2>&1 | tee src/global_launch/voyage_log/combined_log.txt`. The logs will be stored in the `combined_log*.txt` file. Where * can be any suffix like `combined_log_1.txt`, `combined_log_clean.txt`, etc.
 - The `esc[32m` is present in the `[DEBUG]` statement, as that is used for colouring that line green.
 - A on-water testing launch would look something like this, `ros2 launch global_launch main_launch.py record:=true mode:="production" 2>&1 | tee src/global_launch/voyage_log/combined_log.txt`
+- To automatically timestamp each log file (so successive runs don't overwrite each other), append `$( date +%F_%T )` to the filename. For example, `ros2 launch global_launch main_launch.py record:=true mode:=development config:=globals.yaml 2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt`
 <!-- markdownlint-enable MD013 -->

--- a/src/global_launch/README_release.md
+++ b/src/global_launch/README_release.md
@@ -88,15 +88,18 @@ Run the following on the raspberry pi itself.
 re-enter the container and start all the ROS nodes if we're SSHed into
 the raspberry Pi.
 
-2. To enter the container and immediately start our software in production,
+2. To enter the container and immediately start our software in production (for offshore launch),
 run the following and change the container name (example-name) accordingly:
 
    ```bash
    docker start example-name && \
    docker exec -it example-name bash -ic "ros2 launch \
       global_launch main_launch.py record:=true mode:=production \
-      2>&1 | tee src/global_launch/voyage_log/combined_log_$(date %F_%T).txt"
+      config:=launch_globals.yaml 2>&1 | tee src/global_launch/voyage_log/combined_log_$(date %F_%T).txt"
    ```
+
+- Note: If you want to run a specific production launch scenario, for example, on water testing launch then please
+  refer to the src/global_launch/README.md.
 
 - To enter the containter without starting all ROS nodes, run the following:
 

--- a/src/global_launch/config/README.md
+++ b/src/global_launch/config/README.md
@@ -74,6 +74,64 @@ active test plan.
 - _Datatype_: `double`
 - _Acceptable Values_: `(1.0, MAX_DOUBLE)`
 
+### `mock_ais`
+
+The development-only node that publishes mock AIS data in
+different modes based on whether running on water (production) or in development.
+
+**`on_water_mock_ais`**
+
+- _Description_: Enable or disable mock AIS data generation.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
+**`on_water_test_plan`**
+
+- _Description_: The test plan file to use for mock AIS data when on water.
+- _Datatype_: `string`
+- _Acceptable Values_: Any valid test plan filename.
+
+### `mock_gps`
+
+The development-only node that publishes mock GPS data with
+configurable noise and drift.
+
+**`use_gps_noise`**
+
+- _Description_: Enable Gaussian noise on GPS readings.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
+**`use_ocean_drift`**
+
+- _Description_: Enable cumulative ocean current drift on GPS readings.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
+**`use_drift_randomization`**
+
+- _Description_: Enable small random variation to the ocean drift current each tick.
+- _Datatype_: `boolean`
+- _Acceptable Values_: `true`, `false`
+
+**`ocean_drift_speed_kmph`**
+
+- _Description_: Base speed of the ocean current in km/h over ground.
+- _Datatype_: `double`
+- _Range_: `[0.0, MAX_DOUBLE)`
+
+**`ocean_drift_dir_deg`**
+
+- _Description_: Direction the current flows toward in degrees (0=north, 90=east).
+- _Datatype_: `double`
+- _Range_: `(-180.0, 180.0]`
+
+**`ocean_drift_accel_kmph2`**
+
+- _Description_: Acceleration of the drift speed in km/h². Set to 0 for constant drift.
+- _Datatype_: `double`
+- _Range_: `[0.0, MAX_DOUBLE)`
+
 ### `navigate_main`
 
 **`path_planner`**

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -19,12 +19,12 @@ mock_ais:
       on_water_test_plan: "on_water_mock_ais.yaml"
 mock_gps:
    ros__parameters:
-      use_gps_noise: True # Enable Gaussian noise on GPS readings.
-      use_ocean_drift: True # Enable cumulative ocean current drift on GPS readings.
-      use_drift_randomization: True # Enable small random variation to the ocean drift current each tick.
-      ocean_drift_speed_kmph: 0.5 # Base speed of the ocean current in km/h over ground.
-      ocean_drift_dir_deg: 45.0 # Direction the current flows toward in degrees (0=north, 90=east). Range is (-180, 180])
-      ocean_drift_accel_kmph2: 0.0 # Acceleration of the drift speed in km/h^2. Set to 0 for constant drift.
+      use_gps_noise: True
+      use_ocean_drift: True
+      use_drift_randomization: True
+      ocean_drift_speed_kmph: 0.5
+      ocean_drift_dir_deg: 45.0
+      ocean_drift_accel_kmph2: 0.0 
 navigate_main:
    ros__parameters:
       path_planner: "rrtstar"

--- a/src/global_launch/config/globals.yaml
+++ b/src/global_launch/config/globals.yaml
@@ -2,6 +2,7 @@
 /**:
    ros__parameters:
       # Publishers' period (seconds): how often the publishers publish
+      config: "globals.yaml"
       pub_period_sec: 1.0
       global_path_interval_spacing_km: 3.0
       test_plan: "basic.yaml"
@@ -24,7 +25,7 @@ mock_gps:
       use_drift_randomization: True
       ocean_drift_speed_kmph: 0.5
       ocean_drift_dir_deg: 45.0
-      ocean_drift_accel_kmph2: 0.0 
+      ocean_drift_accel_kmph2: 0.0
 navigate_main:
    ros__parameters:
       path_planner: "rrtstar"

--- a/src/global_launch/config/launch_globals.yaml
+++ b/src/global_launch/config/launch_globals.yaml
@@ -4,7 +4,7 @@
       # Publishers' period (seconds): how often the publishers publish
       pub_period_sec: 1.0
       global_path_interval_spacing_km: 3.0
-      test_plan: "basic.yaml"
+      test_plan: "launch.yaml"
 
 # local_pathfinding parameters
 global_path:

--- a/src/global_launch/config/launch_globals.yaml
+++ b/src/global_launch/config/launch_globals.yaml
@@ -2,6 +2,7 @@
 /**:
    ros__parameters:
       # Publishers' period (seconds): how often the publishers publish
+      config: "launch_globals.yaml"
       pub_period_sec: 1.0
       global_path_interval_spacing_km: 3.0
       test_plan: "launch.yaml"

--- a/src/global_launch/config/launch_globals.yaml
+++ b/src/global_launch/config/launch_globals.yaml
@@ -19,12 +19,12 @@ mock_ais:
       on_water_test_plan: "on_water_mock_ais.yaml"
 mock_gps:
    ros__parameters:
-      use_gps_noise: True # Enable Gaussian noise on GPS readings.
-      use_ocean_drift: True # Enable cumulative ocean current drift on GPS readings.
-      use_drift_randomization: True # Enable small random variation to the ocean drift current each tick.
-      ocean_drift_speed_kmph: 0.5 # Base speed of the ocean current in km/h over ground.
-      ocean_drift_dir_deg: 45.0 # Direction the current flows toward in degrees (0=north, 90=east). Range is (-180, 180])
-      ocean_drift_accel_kmph2: 0.0 # Acceleration of the drift speed in km/h^2. Set to 0 for constant drift.
+      use_gps_noise: True
+      use_ocean_drift: True
+      use_drift_randomization: True
+      ocean_drift_speed_kmph: 0.5
+      ocean_drift_dir_deg: 45.0
+      ocean_drift_accel_kmph2: 0.0
 navigate_main:
    ros__parameters:
       path_planner: "rrtstar"

--- a/src/global_launch/config/on_water_globals.yaml
+++ b/src/global_launch/config/on_water_globals.yaml
@@ -2,6 +2,7 @@
 /**:
    ros__parameters:
       # Publishers' period (seconds): how often the publishers publish
+      config: "on_water_globals.yaml" # Name of the global config file
       pub_period_sec: 1.0
       global_path_interval_spacing_km: 3.0
       test_plan: "jericho_on_water_test.yaml"

--- a/src/global_launch/config/on_water_globals.yaml
+++ b/src/global_launch/config/on_water_globals.yaml
@@ -19,12 +19,12 @@ mock_ais:
       on_water_test_plan: "on_water_mock_ais.yaml"
 mock_gps:
    ros__parameters:
-      use_gps_noise: True # Enable Gaussian noise on GPS readings.
-      use_ocean_drift: True # Enable cumulative ocean current drift on GPS readings.
-      use_drift_randomization: True # Enable small random variation to the ocean drift current each tick.
-      ocean_drift_speed_kmph: 0.5 # Base speed of the ocean current in km/h over ground.
-      ocean_drift_dir_deg: 45.0 # Direction the current flows toward in degrees (0=north, 90=east). Range is (-180, 180])
-      ocean_drift_accel_kmph2: 0.0 # Acceleration of the drift speed in km/h^2. Set to 0 for constant drift.
+      use_gps_noise: True
+      use_ocean_drift: True
+      use_drift_randomization: True
+      ocean_drift_speed_kmph: 0.5
+      ocean_drift_dir_deg: 45.0
+      ocean_drift_accel_kmph2: 0.0
 navigate_main:
    ros__parameters:
       path_planner: "rrtstar"

--- a/src/global_launch/config/on_water_globals.yaml
+++ b/src/global_launch/config/on_water_globals.yaml
@@ -4,7 +4,7 @@
       # Publishers' period (seconds): how often the publishers publish
       pub_period_sec: 1.0
       global_path_interval_spacing_km: 3.0
-      test_plan: "basic.yaml"
+      test_plan: "jericho_on_water_test.yaml"
 
 # local_pathfinding parameters
 global_path:
@@ -15,7 +15,7 @@ mock_global_path:
       gps_threshold: 1.5
 mock_ais:
    ros__parameters:
-      on_water_mock_ais: False
+      on_water_mock_ais: True
       on_water_test_plan: "on_water_mock_ais.yaml"
 mock_gps:
    ros__parameters:

--- a/src/global_launch/main_launch.py
+++ b/src/global_launch/main_launch.py
@@ -11,6 +11,7 @@ from launch.actions import (
     IncludeLaunchDescription,
     OpaqueFunction,
     SetEnvironmentVariable,
+    SetLaunchConfiguration,
 )
 from launch.launch_context import LaunchContext
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -25,13 +26,27 @@ SIM_ROS_PACKAGES = ["controller", "boat_simulator", "local_pathfinding", "networ
 ROS_PACKAGES_DIR = os.path.join(
     os.getenv("ROS_WORKSPACE", default="/workspaces/sailbot_workspace"), "src"
 )
-GLOBAL_LAUNCH_CONFIG = os.path.join(ROS_PACKAGES_DIR, "global_launch", "config", "globals.yaml")
+GLOBAL_LAUNCH_CONFIG_DIR = os.path.join(ROS_PACKAGES_DIR, "global_launch", "config")
+
+
+def resolve_config(filename: str) -> str:
+    """Resolve a `config` filename into its absolute path within GLOBAL_LAUNCH_CONFIG_DIR.
+
+    Args:
+        filename (str): The name of a config file in src/global_launch/config.
+
+    Returns:
+        str: The absolute path to the config file.
+    """
+    return os.path.join(GLOBAL_LAUNCH_CONFIG_DIR, filename)
+
+
 GLOBAL_LAUNCH_ARGUMENTS = [
     DeclareLaunchArgument(
         name="config",
-        default_value=GLOBAL_LAUNCH_CONFIG,
-        description="Path to ROS parameter config file. Controls ROS parameters passed into"
-        + " ROS nodes",
+        default_value="defaults.yaml",
+        description="ROS parameter config filename in src/global_launch/config. Controls ROS"
+        + " parameters passed into ROS nodes",
     ),
     # Reference: https://answers.ros.org/question/311471/selecting-log-level-in-ros2-launch-file/
     DeclareLaunchArgument(
@@ -119,10 +134,15 @@ def setup_launch(context: LaunchContext) -> List[Action]:
     mode = LaunchConfiguration("mode").perform(context)
     record = LaunchConfiguration("record").perform(context) == "true"
 
+    config = resolve_config(LaunchConfiguration("config").perform(context))
+
     ros_packages = get_running_ros_packages(mode)
     include_launch_descriptions = get_include_launch_descriptions(ros_packages)
 
-    actions: List[Action] = list(include_launch_descriptions)
+    # Re-publish the resolved absolute config path(s) so the included package launch files,
+    # which read LaunchConfiguration("config") directly, receive a usable file path.
+    actions: List[Action] = [SetLaunchConfiguration("config", config)]
+    actions += list(include_launch_descriptions)
 
     if record:
         save_path = LaunchConfiguration("save_path").perform(context)
@@ -176,7 +196,7 @@ def get_running_ros_packages(mode: str) -> List[str]:
             return SIM_ROS_PACKAGES
         case _:
             raise ValueError(
-                "Invalid launch mode. Must be one of 'production', 'development'," " or 'sim'."
+                "Invalid launch mode. Must be one of 'production'," " 'development', or 'sim'."
             )
 
 

--- a/src/global_launch/main_launch.py
+++ b/src/global_launch/main_launch.py
@@ -44,7 +44,7 @@ def resolve_config(filename: str) -> str:
 GLOBAL_LAUNCH_ARGUMENTS = [
     DeclareLaunchArgument(
         name="config",
-        default_value="defaults.yaml",
+        default_value="globals.yaml",
         description="ROS parameter config filename in src/global_launch/config. Controls ROS"
         + " parameters passed into ROS nodes",
     ),
@@ -65,8 +65,9 @@ GLOBAL_LAUNCH_ARGUMENTS = [
     ),
     DeclareLaunchArgument(
         name="test_plan",
-        default_value="basic.yaml",
-        description="Test plan to be used in development mode for local pathfinding.",
+        default_value="",
+        description="Test plan to be used in development mode for local pathfinding. Leave empty"
+        + " to use the test_plan specified in the config file.",
     ),
     DeclareLaunchArgument(
         name="record",

--- a/src/local_pathfinding/launch/main_launch.py
+++ b/src/local_pathfinding/launch/main_launch.py
@@ -14,46 +14,6 @@ from launch_ros.actions import Node
 # Local launch arguments and constants
 PACKAGE_NAME = "local_pathfinding"
 
-# Add args with DeclareLaunchArguments object(s) and utilize in setup_launch()
-LOCAL_LAUNCH_ARGUMENTS: List[DeclareLaunchArgument] = [
-    DeclareLaunchArgument(
-        name="use_gps_noise",
-        default_value="true",
-        choices=["true", "false"],
-        description="Enable Gaussian noise on GPS readings.",
-    ),
-    DeclareLaunchArgument(
-        name="use_ocean_drift",
-        default_value="true",
-        choices=["true", "false"],
-        description="Enable cumulative ocean current drift on GPS readings.",
-    ),
-    DeclareLaunchArgument(
-        name="use_drift_randomization",
-        default_value="true",
-        choices=["true", "false"],
-        description="Enable small random variation to the ocean drift current each tick.",
-    ),
-    DeclareLaunchArgument(
-        name="ocean_drift_speed_kmph",
-        default_value="0.5",
-        description="Base speed of the ocean current in km/h over ground.",
-    ),
-    DeclareLaunchArgument(
-        name="ocean_drift_dir_deg",
-        default_value="45.0",
-        description=(
-            "Direction the current flows toward in degrees "
-            "(0=north, 90=east). Range is (-180, 180])"
-        ),
-    ),
-    DeclareLaunchArgument(
-        name="ocean_drift_accel_kmph2",
-        default_value="0.0",
-        description="Acceleration of the drift speed in km/h^2. Set to 0 for constant drift.",
-    ),
-]
-
 
 def generate_launch_description() -> LaunchDescription:
     """The launch file entry point. Generates the launch description for the `local_pathfinding`
@@ -67,7 +27,6 @@ def generate_launch_description() -> LaunchDescription:
         [
             *global_launch_arguments,
             *global_environment_vars,
-            *LOCAL_LAUNCH_ARGUMENTS,
             OpaqueFunction(function=setup_launch),
         ]
     )
@@ -137,7 +96,10 @@ def get_navigate_node_description(context: LaunchContext) -> Node:
     inline_params = {"mode": mode}
 
     if mode == "development":
-        inline_params["test_plan"] = LaunchConfiguration("test_plan").perform(context)
+        test_plan = LaunchConfiguration("test_plan").perform(context)
+        # Only override the config's test_plan when one is explicitly provided.
+        if test_plan:
+            inline_params["test_plan"] = test_plan
 
     ros_parameters = [
         LaunchConfiguration("config").perform(context),
@@ -204,12 +166,11 @@ def get_mock_global_path_node_description(context: LaunchContext) -> Node:
     """
     node_name = "mock_global_path"
     test_plan = LaunchConfiguration("test_plan").perform(context)
-    # Pass the shared params file plus inline mode/test_plan dict so only
-    # the first entry is treated as a parameter file path.
-    ros_parameters = [
-        LaunchConfiguration("config").perform(context),
-        {"test_plan": test_plan},
-    ]
+    # Pass the shared params file, then inline the test_plan override only when one is
+    # explicitly provided so the config file's test_plan is used by default.
+    ros_parameters: list = [LaunchConfiguration("config").perform(context)]
+    if test_plan:
+        ros_parameters.append({"test_plan": test_plan})
     ros_arguments: List[SomeSubstitutionsType] = [
         "--log-level",
         [f"{node_name}:=", LaunchConfiguration("log_level")],
@@ -232,10 +193,9 @@ def get_mock_ais_node_description(context: LaunchContext) -> Node:
     """Gets the launch description for the mock ais node."""
     node_name = "mock_ais"
     test_plan = LaunchConfiguration("test_plan").perform(context)
-    ros_parameters = [
-        LaunchConfiguration("config").perform(context),
-        {"test_plan": test_plan},
-    ]
+    ros_parameters: list = [LaunchConfiguration("config").perform(context)]
+    if test_plan:
+        ros_parameters.append({"test_plan": test_plan})
     ros_arguments: List[SomeSubstitutionsType] = [
         "--log-level",
         [f"{node_name}:=", LaunchConfiguration("log_level")],
@@ -258,10 +218,9 @@ def get_mock_wind_sensor_node_description(context: LaunchContext) -> Node:
     """Gets the launch description for the mock wind sensor node"""
     node_name = "mock_wind_sensor"
     test_plan = LaunchConfiguration("test_plan").perform(context)
-    ros_parameters = [
-        LaunchConfiguration("config").perform(context),
-        {"test_plan": test_plan},
-    ]
+    ros_parameters: list = [LaunchConfiguration("config").perform(context)]
+    if test_plan:
+        ros_parameters.append({"test_plan": test_plan})
     ros_arguments: List[SomeSubstitutionsType] = [
         "--log-level",
         [f"{node_name}:=", LaunchConfiguration("log_level")],
@@ -284,32 +243,14 @@ def get_mock_gps_node_description(context: LaunchContext) -> Node:
     """Gets the launch description for the mock gps node"""
     node_name = "mock_gps"
     test_plan = LaunchConfiguration("test_plan").perform(context)
+    inline_params = {}
 
-    use_gps_noise = LaunchConfiguration("use_gps_noise").perform(context)
-    use_gps_noise_bool = use_gps_noise.lower() in ["true", "1", "yes"]
-
-    use_ocean_drift = LaunchConfiguration("use_ocean_drift").perform(context)
-    use_ocean_drift_bool = use_ocean_drift.lower() in ["true", "1", "yes"]
-
-    use_drift_randomization = LaunchConfiguration("use_drift_randomization").perform(context)
-    use_drift_randomization_bool = use_drift_randomization.lower() in ["true", "1", "yes"]
-
-    ocean_drift_speed_kmph = float(LaunchConfiguration("ocean_drift_speed_kmph").perform(context))
-    ocean_drift_dir_deg = float(LaunchConfiguration("ocean_drift_dir_deg").perform(context))
-    ocean_drift_accel_kmph2 = float(
-        LaunchConfiguration("ocean_drift_accel_kmph2").perform(context)
-    )
+    # Only override the config's test_plan when one is explicitly provided.
+    if test_plan:
+        inline_params["test_plan"] = test_plan
     ros_parameters = [
         LaunchConfiguration("config").perform(context),
-        {
-            "test_plan": test_plan,
-            "use_gps_noise": use_gps_noise_bool,
-            "use_ocean_drift": use_ocean_drift_bool,
-            "use_drift_randomization": use_drift_randomization_bool,
-            "ocean_drift_speed_kmph": ocean_drift_speed_kmph,
-            "ocean_drift_dir_deg": ocean_drift_dir_deg,
-            "ocean_drift_accel_kmph2": ocean_drift_accel_kmph2,
-        },
+        inline_params,
     ]
     ros_arguments: List[SomeSubstitutionsType] = [
         "--log-level",

--- a/src/local_pathfinding/launch/main_launch.py
+++ b/src/local_pathfinding/launch/main_launch.py
@@ -4,7 +4,7 @@ import importlib
 import os
 from typing import List, Tuple
 
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import OpaqueFunction
 from launch.launch_context import LaunchContext
 from launch.launch_description import LaunchDescription
 from launch.some_substitutions_type import SomeSubstitutionsType

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
@@ -90,6 +90,13 @@ class MockGPS(Node):
         )
         self._drift_offset_km = cs.XY(0.0, 0.0)  # cumulative offset in km
 
+        self.get_logger().debug(
+            f"ROS2 parameters: use_gps_noise={self._use_noise}, "
+            f"use_ocean_drift={self._use_drift}, use_drift_randomization={self._use_drift_randomization}, "
+            f"ocean_drift_speed_kmph={self._drift_speed_kmph}, ocean_drift_dir_deg={self._drift_dir_deg}, "
+            f"ocean_drift_accel_kmph2={self._drift_accel_kmph2}, pub_period_sec={self.pub_period_sec}"
+        )
+
         # Mock GPS publisher initialization
         self._gps_pub = self.create_publisher(
             msg_type=ci.GPS,

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
@@ -92,9 +92,12 @@ class MockGPS(Node):
 
         self.get_logger().debug(
             f"ROS2 parameters: use_gps_noise={self._use_noise}, "
-            f"use_ocean_drift={self._use_drift}, use_drift_randomization={self._use_drift_randomization}, "
-            f"ocean_drift_speed_kmph={self._drift_speed_kmph}, ocean_drift_dir_deg={self._drift_dir_deg}, "
-            f"ocean_drift_accel_kmph2={self._drift_accel_kmph2}, pub_period_sec={self.pub_period_sec}"
+            f"use_ocean_drift={self._use_drift}, "
+            f"use_drift_randomization={self._use_drift_randomization}, "
+            f"ocean_drift_speed_kmph={self._drift_speed_kmph}, "
+            f"ocean_drift_dir_deg={self._drift_dir_deg}, "
+            f"ocean_drift_accel_kmph2={self._drift_accel_kmph2}, "
+            f"pub_period_sec={self.pub_period_sec}"
         )
 
         # Mock GPS publisher initialization

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -75,6 +75,7 @@ class Sailbot(Node):
                 ("path_planner", rclpy.Parameter.Type.STRING),
                 ("test_plan", rclpy.Parameter.Type.STRING),
                 ("global_path_interval_spacing_km", rclpy.Parameter.Type.DOUBLE),
+                ("config", rclpy.Parameter.Type.STRING),
             ],
         )
 
@@ -145,16 +146,34 @@ class Sailbot(Node):
         self.saved_target_global_waypoint = None
         self.mode = self.get_parameter("mode").get_parameter_value().string_value
         self.planner = self.get_parameter("path_planner").get_parameter_value().string_value
+        global_config = self.get_parameter("config").get_parameter_value().string_value
         self.get_logger().debug(f"Got parameter: {self.planner=}")
 
         # Initialize mock land obstacle
         self.land_multi_polygon = None
         if self.mode in ["development", "sim"]:
             self.test_plan = self.get_parameter("test_plan").get_parameter_value().string_value
+
+            if self.test_plan:
+                self.get_logger().warn("User has manually overridden test plan through CLI")
+
             self.get_logger().info("test plan: " + self.test_plan)
             test_plan = TestPlan(self.test_plan)
             self.land_multi_polygon = test_plan.land
             self.get_logger().info("Loaded mock land data.")
+
+        if global_config == "on_water_globals.yaml":
+            self.get_logger().info(
+                f"On water globals config ({global_config}) is successfully loaded "
+            )
+        elif global_config == "launch_globals.yaml":
+            self.get_logger().info(
+                f"Launch globals config ({global_config}) is successfully loaded "
+            )
+        else:
+            self.get_logger().info(
+                f"Default globals config ({global_config}) is successfully loaded "
+            )
 
     def _now_sec(self) -> float:
         """Return the current ROS clock time in seconds."""

--- a/src/network_systems/launch/main_launch.py
+++ b/src/network_systems/launch/main_launch.py
@@ -5,13 +5,12 @@ import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from typing import List, Tuple
 
-from launch_ros.actions import Node
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction, SetEnvironmentVariable
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 # Deal with Python import paths
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -25,7 +24,6 @@ from ros_info import (  # noqa: E402
 # Local launch arguments and constants
 PACKAGE_NAME = "network_systems"
 NAMESPACE = ""
-global_launch_config = ""
 
 # Add args with DeclareLaunchArguments object(s) and utilize in setup_launch()
 LOCAL_LAUNCH_ARGUMENTS: List[DeclareLaunchArgument] = []
@@ -64,8 +62,6 @@ def get_global_launch_arguments() -> Tuple:
     spec.loader.exec_module(module)  # type: ignore[union-attr] # spec is not None
     global_launch_arguments = module.GLOBAL_LAUNCH_ARGUMENTS
     global_environment_vars = module.ENVIRONMENT_VARIABLES
-    global global_launch_config
-    global_launch_config = module.GLOBAL_LAUNCH_CONFIG
 
     return global_launch_arguments, global_environment_vars
 
@@ -104,7 +100,6 @@ def get_mock_ais_description(context: LaunchContext) -> Node:
     """
     node_name = MOCK_AIS_NODE
     ros_parameters = [
-        global_launch_config,
         {"mode": LaunchConfiguration("mode")},
         *LaunchConfiguration("config").perform(context).split(","),
     ]
@@ -136,7 +131,6 @@ def get_can_transceiver_description(context: LaunchContext) -> Node:
     """
     node_name = CAN_TRANSCEIVER_NODE
     ros_parameters = [
-        global_launch_config,
         {"mode": LaunchConfiguration("mode")},
         *LaunchConfiguration("config").perform(context).split(","),
     ]
@@ -168,7 +162,6 @@ def get_remote_transceiver_description(context: LaunchContext) -> Node:
     """
     node_name = REMOTE_TRANSCEIVER_NODE
     ros_parameters = [
-        global_launch_config,
         {"mode": LaunchConfiguration("mode")},
         *LaunchConfiguration("config").perform(context).split(","),
     ]
@@ -200,7 +193,6 @@ def get_local_transceiver_description(context: LaunchContext) -> Node:
     """
     node_name = "local_transceiver_node"
     ros_parameters = [
-        global_launch_config,
         {"mode": LaunchConfiguration("mode")},
         *LaunchConfiguration("config").perform(context).split(","),
     ]


### PR DESCRIPTION
## Description

Reworks how ROS2 param configs are selected at launch. The `config` launch argument now takes a **filename** (resolved against `src/global_launch/config`) instead of a full path, and adds dedicated config presets for different
operating scenarios.

## Changes

- **`config` arg is now a filename, not a path.** `global_launch/main_launch.py` adds `resolve_config()` to expand the filename to an absolute path, then re-publishes it via `SetLaunchConfiguration` so the included package launch files still receive a usable path.
- **Added scenario config presets** in `src/global_launch/config/`:
    - `globals.yaml` (default) — standard ROS parameter settings.
    - `on_water_globals.yaml` — for on-water testing (production/development/sim).
    - `launch_globals.yaml` — for open-ocean production launch (also usable in
      development/sim).
- **`test_plan` now defaults to empty** and falls back to the value in the
  config file; an explicit CLI `test_plan` override logs a warning.
- **navigate node** reads the `config` filename as a ROS param and logs which
  config was loaded.
- **mock GPS** parameters (noise / ocean drift) moved into `globals.yaml`;
  removed the now-redundant `LOCAL_LAUNCH_ARGUMENTS` from
  `local_pathfinding/launch/main_launch.py`.
- **Docs:** new `config/README.md`, plus README sections documenting the
  config presets and example launch commands.
- **network_system**: Had to remove the hardcoded import of the globals config file path and replace it with the launch description config param, as it would cause globals.yaml ros params to be present if one of the ros params was not present in the config file parsed through the launch desc and local launch param.
 
## Verification
### Production Scenarios
- [x] Run `ros2 launch global_launch main_launch.py mode:=production`
    - [x] You should see a log: `[navigate_main:174]: Default globals config (globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=production config:=on_water_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: On water globals config (on_water_globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=production config:=launch_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: Launch globals config (launch_globals.yaml) is successfully loaded` which is a sign of success
    
### Development Scenarios
- [x] Run `ros2 launch global_launch main_launch.py mode:=development`
    - [x] You should see a log: `[navigate_main:174]: Default globals config (globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=development config:=on_water_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: On water globals config (on_water_globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=development config:=launch_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: Launch globals config (launch_globals.yaml) is successfully loaded` which is a sign of success

### Simulator Scenarios
- [x] Run `ros2 launch global_launch main_launch.py mode:=sim`
    - [x] You should see a log: `[navigate_main:174]: Default globals config (globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=sim config:=on_water_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: On water globals config (on_water_globals.yaml) is successfully loaded` which is a sign of success
- [x] Run `ros2 launch global_launch main_launch.py mode:=sim config:=launch_globals.yaml record:=true`
    - [x] You should see a log: `[navigate_main:174]: Launch globals config (launch_globals.yaml) is successfully loaded` which is a sign of success
    
   