### PR TITLE
Add a kill_ais_node ros param

### DIFF
--- a/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
@@ -39,6 +39,7 @@ public:
     {
         this->declare_parameter("enabled", true);
         this->declare_parameter("manual_mode", false);
+        this->declare_parameter("kill_ais_can", false);
 
         if (!this->get_parameter("enabled").as_bool()) {
             RCLCPP_INFO(this->get_logger(), "CAN Transceiver is DISABLED");
@@ -216,6 +217,9 @@ private:
     // manual mode status
     inline static bool manual_mode_ = false;
 
+    // kill ais can send status
+    inline static bool kill_ais_can_ = false;
+
     std::vector<std::pair<CAN_FP::CanId, std::function<void(const CanFrame &)>>> getCbsForRange(
       CAN_FP::CanId start, CAN_FP::CanId end, void (CanTransceiverIntf::*callback)(const CanFrame &))
     {
@@ -254,6 +258,8 @@ private:
         for (const auto & param : params) {
             if (param.get_name() == "manual_mode") {
                 manual_mode_ = param.as_bool();
+            } else if (param.get_name() == "kill_ais_can") {
+                kill_ais_can_ = param.as_bool();
             }
         }
         rcl_interfaces::msg::SetParametersResult result;
@@ -268,6 +274,11 @@ private:
     void publishAIS(const CanFrame & ais_frame)
     {
         try {
+            // If kill_ais_can is set to true then shut off receiving can messages
+            if (kill_ais_can_) {
+                return;
+            }
+
             CAN_FP::AISShips ais_ship(ais_frame);
 
             int num_ships = ais_ship.getNumShips();


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #907
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
I have added a ros2 param called `kill_ais_can`, which is set to false by default, as we want to read the AIS ship messages from CAN

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Check that we can run `ros2 param set /can_transceiver_node kill_ais_can true` and check by `ros2 param get /can_transceiver_node kill_ais_can` that kill_ais_can changes from it's orignal false to true

### Resources
<!-- Link to any resources that are relevant to this PR. -->

