### PR TITLE
PATH: ROT zone fix

### DIFF
--- a/src/local_pathfinding/local_pathfinding/obstacles.py
+++ b/src/local_pathfinding/local_pathfinding/obstacles.py
@@ -247,7 +247,7 @@ class Boat(Obstacle):
         Case dispatch:
         - no projected collision: circular zone, buffered by (radius + BOAT_BUFFER_KM)
         - straight-line motion: rectangular zone, buffered by BOAT_BUFFER_KM
-        - turning motion: triangular swept region with no extra buffer
+        - turning motion: triangular swept region combined with a buffered circular hull zone
 
         Args:
             ais_ship (ci.HelperAISShip): Updated AIS ship data. Must have the same ID as this Boat.
@@ -332,8 +332,8 @@ class Boat(Obstacle):
         along its turning arc, then builds a triangle from: the bow tip,
         the straight-ahead collision point, and the collision point projected
         along the boat's actual turning direction.
-        No extra buffer is applied; this shape models the swept turning
-        region directly.
+        The projected triangle is combined with a conservative circular zone around the vessel's
+        current hull, including BOAT_BUFFER_KM clearance.
         """
         turn_radius_km = speed_kmps / abs(rot_rps)
         # Positive turn_angle = right turn (clockwise), negative = left turn (counter-clockwise)
@@ -382,7 +382,12 @@ class Boat(Obstacle):
             self.length_km / 2 + future_projected_distance * math.cos(turn_angle),
         ]
 
-        boat_collision_zone = Polygon([A, B, C])
+        turning_projection = Polygon([A, B, C])
+
+        hull_radius_km = math.hypot(self.width_km / 2, self.length_km / 2)
+        current_boat_zone = Point(0.0, 0.0).buffer(hull_radius_km + BOAT_BUFFER_KM)
+
+        boat_collision_zone = current_boat_zone.union(turning_projection)
         self._raw_collision_zone = self._translate_collision_zone(boat_collision_zone)
         self.collision_zone = self._raw_collision_zone
         prepared.prep(self.collision_zone)

--- a/src/local_pathfinding/test/test_obstacles.py
+++ b/src/local_pathfinding/test/test_obstacles.py
@@ -14,7 +14,7 @@ from custom_interfaces.msg import (
     HelperROT,
     HelperSpeed,
 )
-from local_pathfinding.obstacles import Boat, Land, Obstacle
+from local_pathfinding.obstacles import BOAT_BUFFER_KM, Boat, Land, Obstacle
 
 
 def load_pkl(file_path: str) -> Any:
@@ -708,10 +708,6 @@ def test_turning_collision_zone_geometry(
 
     if boat._raw_collision_zone is not None:
 
-        unbuffered = boat._raw_collision_zone
-        coords = np.array(unbuffered.exterior.coords[:-1])
-        assert coords.shape == (3, 2)
-
         bow_y = cs.meters_to_km(ais_ship.length.dimension) / 2
         cog_rad = np.radians(ais_ship.cog.heading)
 
@@ -766,10 +762,20 @@ def test_turning_collision_zone_geometry(
         rotated = np.matmul(expected_local, T.T)
         translation = np.array([dx, dy])
         expected_world = rotated + translation
-        coords_sorted = coords[np.lexsort((coords[:, 0], coords[:, 1]))]
-        expected_sorted = expected_world[np.lexsort((expected_world[:, 0], expected_world[:, 1]))]
+        # The projected turning triangle remains part of the collision zone.
+        for point in expected_world:
+            assert boat.collision_zone.covers(Point(*point))
 
-        assert np.allclose(coords_sorted, expected_sorted, atol=1e-6)
+        # The circular component covers the current hull and the configured safety clearance.
+        ship_center = cs.latlon_to_xy(reference_point, ais_ship.lat_lon)
+        assert not boat.is_valid(ship_center)
+
+        hull_radius_km = np.hypot(boat.width_km / 2, boat.length_km / 2)
+        point_within_clearance = Point(
+            ship_center.x,
+            ship_center.y - hull_radius_km - BOAT_BUFFER_KM * 0.9,
+        )
+        assert boat.collision_zone.contains(point_within_clearance)
 
 
 # Test create collision zone raises error when id of passed ais_ship does not match self's id


### PR DESCRIPTION
Added a cirucluar zone when the ROT is significant. This circular zone covers the boat's hull collision zones. The rest of the projection logic is not touched.