### PR TITLE
Build gazebo-dev for amd64 only

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@
 #
 # OPT-IN: the boat_simulator_gazebo physics backend (Gazebo Harmonic + asv_wave_sim) is a
 # ~1.8 GB dependency closure that most of the team never touches, so it is not part of the
-# base dev image. Enable it by uncommenting the INSTALL_GAZEBO build arg in
-# docker-compose.yml, then rebuild the container.
+# base dev image. Enable it by adding gazebo/docker-compose.gazebo.yml to
+# "dockerComposeFile" in devcontainer.json, then rebuild the container.
 # ---------------------------------------------------------------------------------------
 ARG BASE_TAG=setup-included-2
 ARG GAZEBO_TAG=gazebo

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,20 +2,27 @@
 {
   "name": "Sailbot Workspace",
   "dockerComposeFile": [
-    "docker-compose.yml"
+    "docker-compose.yml",
     // We do not use anymore. We pulled website development out of docker in PR #614
     // "website/docker-compose.website.yml", // website
 
     // Uncomment the files containing the programs you need
     // "docs/docker-compose.docs.yml", // docs
-    // "gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
+    "gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
+
+    // Renders OpenGL GUIs (Gazebo, RViz) on the GPU instead of the CPU. Must stay after
+    // docker-compose.yml, whose LIBGL_ALWAYS_SOFTWARE it overrides. See wsl/README.md.
+    "wsl/docker-compose.wsl.yml" // WSL2 GPU passthrough for OpenGL GUIs (WSL2 hosts only)
   ],
   "service": "sailbot-workspace",
   "forwardPorts": [3005],
   "workspaceFolder": "/workspaces/sailbot_workspace",
   "remoteUser": "ros",
   "containerEnv": {
-    "LIBGL_ALWAYS_SOFTWARE": "1" // Needed for software rendering of opengl
+    // Selects which Gazebo release asv_wave_sim builds against. It falls back to Garden's
+    // libraries when unset, which does not configure against the Harmonic install used by
+    // the boat_simulator_gazebo backend.
+    "GZ_VERSION": "harmonic"
   },
   // Set *default* container specific settings.json values on container create.
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 
     // Uncomment the files containing the programs you need
     // "docs/docker-compose.docs.yml", // docs
+    // "gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
   ],
   "service": "sailbot-workspace",
   "forwardPorts": [3005],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,12 @@
 
     // Uncomment the files containing the programs you need
     // "docs/docker-compose.docs.yml", // docs
-    "gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
+
+    // Uncomment the two compose files below to use the gazebo simulator
+    // "gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
 
     // Renders OpenGL GUIs (Gazebo, RViz) on the GPU instead of the CPU. Must stay after
-    // docker-compose.yml, whose LIBGL_ALWAYS_SOFTWARE it overrides. See wsl/README.md.
-    "wsl/docker-compose.wsl.yml" // WSL2 GPU passthrough for OpenGL GUIs (WSL2 hosts only)
+    // "wsl/docker-compose.wsl.yml" // WSL2 GPU passthrough for OpenGL GUIs (WSL2 hosts only)
   ],
   "service": "sailbot-workspace",
   "forwardPorts": [3005],

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,10 @@ services:
       dockerfile: Dockerfile
       # Opt in to the Gazebo simulator backend (Gazebo Harmonic + a prebuilt
       # asv_wave_sim). Off by default because only the boat_simulator and pathfinding team needs it.
-      # Set INSTALL_GAZEBO to "true" if wanting to use the Gazebo simulator
+      # To enable it, add gazebo/docker-compose.gazebo.yml to "dockerComposeFile" in
+      # devcontainer.json rather than flipping this to "true" - the overlay also pins the
+      # amd64 platform that gazebo-dev requires. See gazebo/README.md.
+      # CI asserts this stays "false" (see the gazebo-disabled-by-default job).
       args:
         INSTALL_GAZEBO: "false"
     # Use "always" instead if this container should restart even after some manual stops.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,6 +19,18 @@ services:
     network_mode: host
     privileged: true
     user: ros
+    environment:
+      # Force Mesa to render OpenGL on the CPU (llvmpipe). The container has no GPU: there is
+      # no /dev/dri and no vendor userspace driver, so the hardware GLX path fails outright
+      # ("failed to load driver: swrast") and any GUI using it - Gazebo, RViz - aborts on
+      # startup rather than falling back. Software rendering is therefore the only thing that
+      # works by default, at the cost of being slow.
+      #
+      # This lives here rather than in devcontainer.json's "containerEnv" so that a compose
+      # overlay can override it: containerEnv is applied last by the Dev Containers extension
+      # and would win over any overlay. wsl/docker-compose.wsl.yml sets it back to "0" once it
+      # has supplied a real GPU driver. See wsl/README.md.
+      LIBGL_ALWAYS_SOFTWARE: "1"
     group_add:
       - dialout
     devices:

--- a/.devcontainer/gazebo/README.md
+++ b/.devcontainer/gazebo/README.md
@@ -12,6 +12,11 @@
   [`../docker-compose.yml`](../docker-compose.yml)) selects this image as the
   base in [`../Dockerfile`](../Dockerfile) instead of compiling
   `asv_wave_sim` (~15 minutes) locally on every rebuild
+- Published for `linux/amd64` only. OSRF does not publish the
+  `ros-humble-ros-gzharmonic*` bridge packages this image needs for `arm64`
+  on jammy (only the bare `gz-harmonic` engine), so it cannot be built
+  natively for Apple Silicon - Docker Desktop falls back to emulating the
+  `amd64` image there instead
 
 ## How to build
 

--- a/.devcontainer/gazebo/README.md
+++ b/.devcontainer/gazebo/README.md
@@ -8,15 +8,40 @@
 - Published separately from `dev` (as
   `ghcr.io/ubcsailbot/sailbot_workspace/gazebo-dev`) so that most developers,
   who never run the simulator, never pull or build its ~1.8 GB dependency
-  closure. Opting in (`INSTALL_GAZEBO` in
-  [`../docker-compose.yml`](../docker-compose.yml)) selects this image as the
-  base in [`../Dockerfile`](../Dockerfile) instead of compiling
+  closure. Opting in (see [How to enable it](#how-to-enable-it)) selects this
+  image as the base in [`../Dockerfile`](../Dockerfile) instead of compiling
   `asv_wave_sim` (~15 minutes) locally on every rebuild
 - Published for `linux/amd64` only. OSRF does not publish the
   `ros-humble-ros-gzharmonic*` bridge packages this image needs for `arm64`
   on jammy (only the bare `gz-harmonic` engine), so it cannot be built
   natively for Apple Silicon - Docker Desktop falls back to emulating the
   `amd64` image there instead
+
+## How to enable it
+
+Add the overlay to `dockerComposeFile` in
+[`../devcontainer.json`](../devcontainer.json) by uncommenting this line:
+
+```jsonc
+"gazebo/docker-compose.gazebo.yml", // Gazebo simulator backend (amd64 only)
+```
+
+then run the "Dev Containers: Rebuild Container" VS Code command.
+
+[`docker-compose.gazebo.yml`](docker-compose.gazebo.yml) sets the
+`INSTALL_GAZEBO` build arg to `"true"`, which switches the base image in
+[`../Dockerfile`](../Dockerfile) over to `gazebo-dev`, and pins the service to
+`linux/amd64`. The platform pin is what makes this work on Apple Silicon:
+without it Docker targets the host's native `arm64`, finds no `arm64` variant
+of `gazebo-dev`, and fails with "no match for platform in manifest" instead of
+falling back to emulation. Expect it to be slow there - the sim runs
+translated, on top of software rendering that already has no GPU inside Docker
+on macOS.
+
+Editing `INSTALL_GAZEBO` directly in [`../docker-compose.yml`](../docker-compose.yml)
+also works, but the overlay is preferred: it leaves the base file at `"false"`,
+which is what the `gazebo-disabled-by-default` CI check enforces, so there is
+no local edit to remember to revert before committing.
 
 ## How to build
 
@@ -34,8 +59,8 @@
 7. In [`../Dockerfile`](../Dockerfile), update the `GAZEBO_TAG` build arg
    default with the short description above
 8. Once the workflow successfully completes, run the "Dev Containers:
-   Rebuild Container" VS Code command to use the newly built image (with
-   `INSTALL_GAZEBO` uncommented in `../docker-compose.yml`)
+   Rebuild Container" VS Code command to use the newly built image (with the
+   overlay enabled, per [How to enable it](#how-to-enable-it))
 
 ### Debugging locally
 

--- a/.devcontainer/gazebo/docker-compose.gazebo.yml
+++ b/.devcontainer/gazebo/docker-compose.gazebo.yml
@@ -1,10 +1,5 @@
-# Overlay that turns on the Gazebo simulator backend. Add it to "dockerComposeFile" in
-# devcontainer.json (see .devcontainer/gazebo/README.md) and rebuild the container.
-#
-# Kept as an overlay rather than an edit to the main docker-compose.yml for two reasons:
-# the platform pin below must NOT apply to the default build, and leaving the base file at
-# INSTALL_GAZEBO "false" keeps CI's gazebo-disabled-by-default check happy without anyone
-# having to remember to revert a local edit before committing.
+# Overlay that turns on the Gazebo simulator backend.
+
 services:
   sailbot-workspace:
     # gazebo-dev is published for linux/amd64 only, because OSRF does not build the
@@ -12,9 +7,9 @@ services:
     # arm64 host (Apple Silicon) targets its native platform, finds no arm64 variant in the
     # manifest, and fails the build with "no match for platform in manifest" rather than
     # falling back to emulation. With it, the amd64 image runs under Rosetta 2 / QEMU.
-    #
-    # This belongs here and not in the base compose file: pinning amd64 unconditionally
-    # would force every arm64 user into emulation even when they are not running Gazebo.
+    # For Apple Silicon users, expect poor performance when using the Gazebo GUI. We recommend
+    # running Gazebo headless.
+
     platform: linux/amd64
     build:
       args:

--- a/.devcontainer/gazebo/docker-compose.gazebo.yml
+++ b/.devcontainer/gazebo/docker-compose.gazebo.yml
@@ -1,0 +1,21 @@
+# Overlay that turns on the Gazebo simulator backend. Add it to "dockerComposeFile" in
+# devcontainer.json (see .devcontainer/gazebo/README.md) and rebuild the container.
+#
+# Kept as an overlay rather than an edit to the main docker-compose.yml for two reasons:
+# the platform pin below must NOT apply to the default build, and leaving the base file at
+# INSTALL_GAZEBO "false" keeps CI's gazebo-disabled-by-default check happy without anyone
+# having to remember to revert a local edit before committing.
+services:
+  sailbot-workspace:
+    # gazebo-dev is published for linux/amd64 only, because OSRF does not build the
+    # ros-humble-ros-gzharmonic* packages for arm64 on jammy. Without this pin, Docker on an
+    # arm64 host (Apple Silicon) targets its native platform, finds no arm64 variant in the
+    # manifest, and fails the build with "no match for platform in manifest" rather than
+    # falling back to emulation. With it, the amd64 image runs under Rosetta 2 / QEMU.
+    #
+    # This belongs here and not in the base compose file: pinning amd64 unconditionally
+    # would force every arm64 user into emulation even when they are not running Gazebo.
+    platform: linux/amd64
+    build:
+      args:
+        INSTALL_GAZEBO: "true"

--- a/.devcontainer/gazebo/gazebo.Dockerfile
+++ b/.devcontainer/gazebo/gazebo.Dockerfile
@@ -14,14 +14,9 @@ ARG ROS_DISTRO_NAME=humble
 ARG ASV_WAVE_SIM_REF=master
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Gazebo itself. The base image ships Ignition Fortress (ros-humble-ros-gz-*), which
-# Conflicts with the Harmonic bridge, so apt swaps it here rather than at runtime.
-#
+# Gazebo itself.
 # amd64 only: OSRF publishes the bare gz-${GZ_DISTRO} engine for arm64, but not the
-# ros-${ROS_DISTRO_NAME}-ros-gz${GZ_DISTRO}* bridge packages this image actually needs -
-# their jammy/arm64 package index has zero ros-gz entries. Building this image for arm64
-# fails with "Unable to locate package" on that line; see the platforms input in
-# ../../.github/workflows/build-gazebo-dev-image.yml.
+# ros-${ROS_DISTRO_NAME}-ros-gz${GZ_DISTRO}* bridge packages this arm64 image needs
 RUN set -eux \
     && curl -sSL https://packages.osrfoundation.org/gazebo.gpg \
         -o /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \

--- a/.devcontainer/gazebo/gazebo.Dockerfile
+++ b/.devcontainer/gazebo/gazebo.Dockerfile
@@ -16,6 +16,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Gazebo itself. The base image ships Ignition Fortress (ros-humble-ros-gz-*), which
 # Conflicts with the Harmonic bridge, so apt swaps it here rather than at runtime.
+#
+# amd64 only: OSRF publishes the bare gz-${GZ_DISTRO} engine for arm64, but not the
+# ros-${ROS_DISTRO_NAME}-ros-gz${GZ_DISTRO}* bridge packages this image actually needs -
+# their jammy/arm64 package index has zero ros-gz entries. Building this image for arm64
+# fails with "Unable to locate package" on that line; see the platforms input in
+# ../../.github/workflows/build-gazebo-dev-image.yml.
 RUN set -eux \
     && curl -sSL https://packages.osrfoundation.org/gazebo.gpg \
         -o /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \

--- a/.devcontainer/wsl/README.md
+++ b/.devcontainer/wsl/README.md
@@ -1,0 +1,108 @@
+# WSL2 GPU Passthrough
+
+## What it is
+
+An opt-in compose overlay that lets OpenGL GUIs inside the Dev Container - the
+Gazebo GUI, RViz - render on the Windows GPU instead of on the CPU.
+
+By default the container has no GPU at all: no `/dev/dri`, no vendor userspace
+driver. The hardware GLX path fails outright rather than degrading, so
+[`../docker-compose.yml`](../docker-compose.yml) sets
+`LIBGL_ALWAYS_SOFTWARE=1` to force Mesa's `llvmpipe` software rasterizer. That
+keeps GUIs alive but makes them very slow. The Gazebo GUI is the worst case: the
+`asv_wave_sim` ocean is a 256x256 FFT mesh regenerated at 30 Hz, which pins two
+CPU cores and leaves the window drawing at a fraction of a frame per second -
+usually mistaken for the GUI failing to load.
+
+WSL2 already exposes the Windows GPU to Linux; the container is one mount away
+from using it:
+
+| Piece                                | Status without this overlay      |
+| ------------------------------------ | -------------------------------- |
+| `/dev/dxg`                           | present (via `privileged: true`) |
+| Mesa d3d12 driver (`d3d12_dri.so`)   | present in the image             |
+| `/usr/lib/wsl/lib` (`libd3d12core.so`, `libdxcore.so`, ...) | **missing**    |
+
+Windows injects `/usr/lib/wsl` into every WSL2 distro, but Docker does not carry
+it into containers. This overlay bind-mounts it read-only, points
+`GALLIUM_DRIVER` at d3d12, and sets `LIBGL_ALWAYS_SOFTWARE` back to `0`.
+
+## Requirements
+
+- A **WSL2** host with a GPU that has WSL drivers (any reasonably current
+  NVIDIA, AMD, or Intel Windows driver)
+- `/usr/lib/wsl/lib` non-empty in the WSL distro Docker runs in. Check from a
+  WSL shell on the host, outside the container:
+
+  ```bash
+  ls /usr/lib/wsl/lib
+  ```
+
+  It should list `libd3d12core.so`, `libdxcore.so`, and similar.
+
+**This overlay is WSL2-only.** On macOS or a native Linux host `/usr/lib/wsl`
+does not exist, and Docker creates an empty directory for a missing bind-mount
+source instead of failing. The mount would silently succeed, `d3d12` would find
+nothing, and `LIBGL_ALWAYS_SOFTWARE=0` would leave the GUI with no working
+driver - a hard abort on startup instead of a slow window. Leave it disabled
+there.
+
+## How to enable it
+
+Add the overlay to `dockerComposeFile` in
+[`../devcontainer.json`](../devcontainer.json) by uncommenting this line:
+
+```jsonc
+"wsl/docker-compose.wsl.yml", // WSL2 GPU passthrough for OpenGL GUIs (WSL2 hosts only)
+```
+
+then run the "Dev Containers: Rebuild Container" VS Code command.
+
+It must stay **after** `docker-compose.yml` in the list, since that is the file
+whose `LIBGL_ALWAYS_SOFTWARE` it overrides. Compose applies files in order and
+later ones win.
+
+Like the Gazebo overlay, it ships commented out and CI asserts it stays that
+way (see the `gazebo-disabled-by-default` job in
+[`../../.github/workflows/tests.yml`](../../.github/workflows/tests.yml)):
+enabling it for everyone would break every non-WSL host and every CI job.
+Uncomment it locally, and revert before committing.
+
+## Verifying it worked
+
+After the rebuild, run any OpenGL GUI and check which renderer Ogre selected:
+
+```bash
+gz sim -r shapes.sdf              # then, in another terminal:
+grep -E "GL_RENDERER|GL_VENDOR" ~/.gz/rendering/ogre2.log
+```
+
+Working:
+
+```text
+GL_RENDERER = D3D12 (<your GPU name>)
+```
+
+Still on the CPU:
+
+```text
+GL_RENDERER = llvmpipe (LLVM 15.0.7, 256 bits)
+```
+
+If it is still `llvmpipe`, check `ls /usr/lib/wsl/lib` **inside** the container -
+an empty directory means the bind-mount source did not exist on the host.
+
+## Notes
+
+- `LD_LIBRARY_PATH` is set to `/usr/lib/wsl/lib:/opt/ros/humble/lib`. The ROS
+  path is not redundant: a compose `environment:` value replaces the image's
+  `ENV` rather than extending it, and
+  [`../base-dev/base-dev.Dockerfile`](../base-dev/base-dev.Dockerfile) sets
+  `LD_LIBRARY_PATH=/opt/ros/humble/lib`. Dropping it breaks library resolution
+  for ROS binaries.
+- GPU access does not reduce the WSL VM's memory limit, which the Gazebo GUI can
+  otherwise exhaust (it holds ~1 GB resident on top of the server). If the VM
+  has less than about 8 GB, raise it in `%UserProfile%\.wslconfig` on Windows.
+- This overlay is independent of the Gazebo overlay. Enabling both is the normal
+  setup for running the simulator with its GUI on Windows; enabling only this one
+  still speeds up RViz and any other OpenGL tool.

--- a/.devcontainer/wsl/docker-compose.wsl.yml
+++ b/.devcontainer/wsl/docker-compose.wsl.yml
@@ -1,0 +1,37 @@
+# Overlay that gives the container WSL2's GPU, so OpenGL GUIs (the Gazebo GUI, RViz) render
+# on hardware instead of on the CPU.
+#
+# WSL2 exposes the Windows GPU to Linux through /dev/dxg plus a set of userspace libraries
+# that Windows injects into every WSL distro at /usr/lib/wsl/lib (libd3d12core.so,
+# libdxcore.so, and friends). Mesa's d3d12 Gallium driver - already present in the image as
+# /usr/lib/x86_64-linux-gnu/dri/d3d12_dri.so - translates OpenGL onto them.
+#
+# /dev/dxg is already visible inside the container because the base compose file sets
+# `privileged: true`, so no `devices:` entry is needed here. Adding one would risk replacing
+# rather than extending the base file's /dev/ttyS0 mapping. The libraries are the only
+# missing piece, and without them Mesa finds no usable driver and silently falls back to
+# llvmpipe, the software rasterizer.
+#
+# WSL2 HOSTS ONLY. On macOS or a native Linux host /usr/lib/wsl does not exist; Docker
+# would create an empty directory for it instead of failing, and LIBGL_ALWAYS_SOFTWARE=0
+# would then leave the GUI with no working driver at all. See README.md.
+
+services:
+  sailbot-workspace:
+    volumes:
+      # Read-only: this tree is managed by Windows and must match the host driver version.
+      - /usr/lib/wsl:/usr/lib/wsl:ro
+
+    environment:
+      # Undo the base compose file's software-rendering fallback now that a real driver is
+      # available. Compose overlays override scalar values from earlier files, which is why
+      # LIBGL_ALWAYS_SOFTWARE is set there rather than in devcontainer.json's "containerEnv"
+      # (containerEnv is applied last and would win over this).
+      LIBGL_ALWAYS_SOFTWARE: "0"
+
+      # Pick Mesa's d3d12 driver explicitly. Auto-detection usually finds it, but only after
+      # probing for a /dev/dri node that WSL does not provide, so naming it avoids a fallback
+      # to llvmpipe that looks like success apart from being ~100x slower.
+      GALLIUM_DRIVER: d3d12
+
+      LD_LIBRARY_PATH: /usr/lib/wsl/lib:/opt/ros/humble/lib

--- a/.github/workflows/build-gazebo-dev-image.yml
+++ b/.github/workflows/build-gazebo-dev-image.yml
@@ -23,13 +23,8 @@ jobs:
         timeout-minutes: 240
 
         steps:
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v4
-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
-              with:
-                  platforms: linux/arm64,linux/amd64
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v4
@@ -49,6 +44,9 @@ jobs:
                   tags: |
                       ghcr.io/ubcsailbot/sailbot_workspace/gazebo-dev:${{ inputs.tag }}
                       ghcr.io/ubcsailbot/sailbot_workspace/gazebo-dev:latest
-                  platforms: linux/arm64,linux/amd64
+                  # amd64 only: OSRF does not publish the ros-humble-ros-gzharmonic* bridge
+                  # packages for arm64 on jammy, only the bare gz-harmonic engine. See the
+                  # note above the apt install in gazebo.Dockerfile.
+                  platforms: linux/amd64
                   cache-from: type=gha
                   cache-to: type=gha,mode=max

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,3 +84,28 @@ jobs:
           echo "::error file=.devcontainer/docker-compose.yml::INSTALL_GAZEBO must stay set to \"false\" - every CI job builds this compose file, and leaving it enabled would make Gazebo mandatory for everyone instead of opt-in."
           exit 1
         fi
+
+  wsl-gpu-disabled-by-default:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - name: Checkout workspace
+      uses: actions/checkout@v7
+
+    # The WSL GPU overlay bind-mounts /usr/lib/wsl, which only exists on a WSL2 host. Docker
+    # creates an empty directory for a missing bind-mount source rather than failing, so on
+    # macOS, native Linux, and CI the mount would appear to succeed while leaving no usable
+    # GL driver - and the overlay also sets LIBGL_ALWAYS_SOFTWARE=0, removing the software
+    # fallback those hosts depend on. Enabled by default it would break every non-WSL
+    # developer silently. See .devcontainer/wsl/README.md.
+    - name: Ensure the WSL GPU overlay is not enabled for the Main branch
+      run: |
+        if grep -nE '^\s*"wsl/docker-compose\.wsl\.yml"' .devcontainer/devcontainer.json; then
+          echo "::error file=.devcontainer/devcontainer.json::The wsl/docker-compose.wsl.yml entry in dockerComposeFile must stay commented out - it is WSL2-only and disables the software-rendering fallback that every other host needs."
+          exit 1
+        fi
+
+        if ! grep -qE '^\s*LIBGL_ALWAYS_SOFTWARE:\s*"1"\s*$' .devcontainer/docker-compose.yml; then
+          echo "::error file=.devcontainer/docker-compose.yml::LIBGL_ALWAYS_SOFTWARE must stay set to \"1\" in the base compose file - the container has no GPU by default, and the hardware GL path aborts rather than falling back to software rendering."
+          exit 1
+        fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,17 @@ jobs:
     - name: Checkout workspace
       uses: actions/checkout@v7
 
+    # Gazebo can be turned on two ways, so both are checked: the build arg in the base
+    # compose file, and the overlay in devcontainer.json. Leaving either enabled would make
+    # Gazebo mandatory for everyone instead of opt-in, and would pull the amd64-only
+    # gazebo-dev image into every CI job.
     - name: Ensure Gazebo is not installed for the Main branch
       run: |
+        if grep -nE '^\s*"gazebo/docker-compose\.gazebo\.yml"' .devcontainer/devcontainer.json; then
+          echo "::error file=.devcontainer/devcontainer.json::The gazebo/docker-compose.gazebo.yml entry in dockerComposeFile must stay commented out - it sets INSTALL_GAZEBO=true and pins linux/amd64, which would apply to everyone including CI."
+          exit 1
+        fi
+
         if ! grep -qE '^\s*INSTALL_GAZEBO:\s*"false"\s*$' .devcontainer/docker-compose.yml; then
           echo "::error file=.devcontainer/docker-compose.yml::INSTALL_GAZEBO must stay set to \"false\" - every CI job builds this compose file, and leaving it enabled would make Gazebo mandatory for everyone instead of opt-in."
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,12 +92,7 @@ jobs:
     - name: Checkout workspace
       uses: actions/checkout@v7
 
-    # The WSL GPU overlay bind-mounts /usr/lib/wsl, which only exists on a WSL2 host. Docker
-    # creates an empty directory for a missing bind-mount source rather than failing, so on
-    # macOS, native Linux, and CI the mount would appear to succeed while leaving no usable
-    # GL driver - and the overlay also sets LIBGL_ALWAYS_SOFTWARE=0, removing the software
-    # fallback those hosts depend on. Enabled by default it would break every non-WSL
-    # developer silently. See .devcontainer/wsl/README.md.
+    # If the composes files are running/enabled by default it would break every non-WSL developer silently. See .devcontainer/wsl/README.md.
     - name: Ensure the WSL GPU overlay is not enabled for the Main branch
       run: |
         if grep -nE '^\s*"wsl/docker-compose\.wsl\.yml"' .devcontainer/devcontainer.json; then


### PR DESCRIPTION
OSRF does not publish the ros-humble-ros-gzharmonic* bridge packages for arm64 on jammy, only the bare gz-harmonic engine, so the multi-arch build failed with "Unable to locate package ros-humble-ros-gzharmonic" on the arm64 leg. Drop arm64 (and the now-unused QEMU setup) and document why in the Dockerfile and README.

<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Fixing the Gazebo Docker image
