### PR TITLE
Add support for debug rudder data frame and fix AIS ROT bounds

### DIFF
--- a/src/network_systems/README.md
+++ b/src/network_systems/README.md
@@ -104,6 +104,9 @@ For example:
 ros2 launch network_systems main_launch.py
 ```
 
+Set `rudder_debug:=true` to force headings to come debug rudder data frame `0x204`.
+Otherwise, default to standard rudder data frame.
+
 This is the best option if multiple modules need to be run at once. Launch
 configurations are found under the [config](config/) folder. These
 configurations define which modules to enable/disable and what parameters to

--- a/src/network_systems/config/can_transceiver/can_transceiver_template.yaml
+++ b/src/network_systems/config/can_transceiver/can_transceiver_template.yaml
@@ -2,6 +2,7 @@
 can_transceiver_node:
   ros__parameters:
     enabled: true
+    rudder_debug: false # force heading input to use RUDDER_DEBUG_DATA_FRAME
     # CAN log replay (only used when mode:=can)
     # can_replay_file: "/workspaces/sailbot_workspace/src/network_systems/lib/can_log/combined_can_frames.csv"    # path to a candump-style CSV log; empty disables replay outside of can mode
     # can_replay_rate: 1.0   # 1.0 = real time, 2.0 = twice as fast, <= 0 = as fast as possible

--- a/src/network_systems/launch/main_launch.py
+++ b/src/network_systems/launch/main_launch.py
@@ -27,7 +27,14 @@ PACKAGE_NAME = "network_systems"
 NAMESPACE = ""
 
 # Add args with DeclareLaunchArguments object(s) and utilize in setup_launch()
-LOCAL_LAUNCH_ARGUMENTS: List[DeclareLaunchArgument] = []
+LOCAL_LAUNCH_ARGUMENTS: List[DeclareLaunchArgument] = [
+    DeclareLaunchArgument(
+        name="rudder_debug",
+        default_value="false",
+        choices=["true", "false"],
+        description="Force rudder heading data to use RUDDER_DEBUG_DATA_FRAME.",
+    )
+]
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -164,6 +171,7 @@ def get_can_transceiver_description(context: LaunchContext) -> Node:
     ros_parameters = [
         {"mode": LaunchConfiguration("mode")},
         *LaunchConfiguration("config").perform(context).split(","),
+        {"rudder_debug": LaunchConfiguration("rudder_debug")},
     ]
     ros_arguments: List[SomeSubstitutionsType] = [
         "--log-level",

--- a/src/network_systems/lib/cmn_hdrs/shared_constants.h
+++ b/src/network_systems/lib/cmn_hdrs/shared_constants.h
@@ -108,8 +108,8 @@ constexpr float TRIM_UBND = 40.0;
 
 // boat rotation
 // See https://documentation.spire.com/ais-fundamentals/rate-of-turn-rot/ for how ROT works
-constexpr int8_t ROT_LBND = -126;
-constexpr int8_t ROT_UBND = 126;
+constexpr int8_t ROT_LBND = -127;
+constexpr int8_t ROT_UBND = 127;
 
 // boat dimension
 constexpr float SHIP_DIMENSION_LBND = 1;      // arbitrary number

--- a/src/network_systems/projects/can_transceiver/inc/can_frame_parser.h
+++ b/src/network_systems/projects/can_transceiver/inc/can_frame_parser.h
@@ -100,8 +100,9 @@ enum class CanId : canid_t {
     SENSE_HEARTBEAT       = 0x133,
     MAIN_HEARTBEAT        = 0x134,
     HEARTBEAT_END         = 0x134,
-    DEBUG_START           = 0x200,
-    DEBUG_END             = 0x2FF
+    DEBUG_START             = 0x200,
+    RUDDER_DEBUG_DATA_FRAME = 0x204,
+    DEBUG_END               = 0x2FF
 };
 
 inline bool isValidCanId(canid_t id)
@@ -140,6 +141,7 @@ static const std::map<CanId, std::string> CAN_DESC{
   {CanId::SAIL_AIS, "SAIL_AIS (AIS ship data)"},
   {CanId::SAIL_WIND, "SAIL_WIND (Mast wind sensor)"},
   {CanId::RUDDER_DATA_FRAME, "RUDDER_DATA_FRAME (Rudder data from ecompass)"},
+  {CanId::RUDDER_DEBUG_DATA_FRAME, "RUDDER_DEBUG_DATA_FRAME (Debug rudder data from ecompass)"},
   {CanId::PATH_GPS_DATA_FRAME, "PATH_GPS_DATA_FRAME (GPS latitude)"},
   {CanId::DATA_WIND, "DATA_WIND (Hull wind sensor)"},
   {CanId::TEMP_SENSOR_START, "TEMP_SENSOR_START (Start of temperature sensor range)"},
@@ -961,6 +963,81 @@ private:
     void checkBounds() const;
 
     float heading_;
+};
+
+/**
+ * @brief A Rudder Debug Data class derived from the BaseFrame. Represents debug data from the rudder controller.
+ *
+ */
+class RudderDebugData final : public BaseFrame
+{
+public:
+    static constexpr std::array<CanId, 1> RUDDER_DEBUG_DATA_IDS      = {CanId::RUDDER_DEBUG_DATA_FRAME};
+    static constexpr uint8_t              CAN_BYTE_DLEN_             = 16;
+    static constexpr uint8_t              BYTE_OFF_ACTUAL_RUDDER     = 0;
+    static constexpr uint8_t              BYTE_OFF_ROLL              = 2;
+    static constexpr uint8_t              BYTE_OFF_PITCH             = 4;
+    static constexpr uint8_t              BYTE_OFF_HEADING           = 6;
+    static constexpr uint8_t              BYTE_OFF_COMMANDED_RUDDER  = 8;
+    static constexpr uint8_t              BYTE_OFF_INTEGRAL          = 10;
+    static constexpr uint8_t              BYTE_OFF_DERIVATIVE        = 12;
+    static constexpr uint8_t              BYTE_OFF_SPEED_OVER_GROUND = 14;
+
+    /**
+     * @brief Explicitly deleted no-argument constructor
+     *
+     */
+    RudderDebugData() = delete;
+
+    /**
+     * @brief Construct a RudderDebugData object from a Linux CanFrame representation
+     *
+     * @param cf Linux CanFrame
+     */
+    explicit RudderDebugData(const CanFrame & cf);
+
+    /**
+     * @return the custom_interfaces ROS representation of the RudderDebugData heading
+     */
+    msg::HelperHeading toRosMsg() const;
+
+    /**
+     * @return the Linux CanFrame representation of the RudderDebugData object
+     */
+    CanFrame toLinuxCan() const override;
+
+    /**
+     * @return A string that can be printed or logged to debug a RudderDebugData object
+     */
+    std::string debugStr() const override;
+
+    /**
+     * @brief A string representation of the RudderDebugData object
+     *
+     */
+    std::string toString() const override;
+
+private:
+    /**
+     * @brief Private helper constructor for RudderDebugData objects
+     *
+     * @param id CanId of the RudderDebugData
+     */
+    explicit RudderDebugData(CanId id);
+
+    /**
+     * @brief Preserve the frame class pattern without imposing bounds on debug data.
+     */
+    void checkBounds() const;
+
+    float   actual_rudder_angle_;
+    float   roll_;
+    float   pitch_;
+    float   heading_;
+    float   commanded_rudder_angle_;
+    int32_t integral_;
+    int32_t derivative_;
+    float   speed_over_ground_;
 };
 
 /**

--- a/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
@@ -940,17 +940,39 @@ void RudderData::checkBounds() const
 // RudderDebugData START
 RudderDebugData::RudderDebugData(const CanFrame & cf) : RudderDebugData(static_cast<CanId>(cf.can_id))
 {
-    std::array<uint16_t, 8> raw{};
-    std::memcpy(raw.data(), cf.data, CAN_BYTE_DLEN_);
+    uint16_t raw_actual_rudder;
+    uint16_t raw_roll;
+    uint16_t raw_pitch;
+    uint16_t raw_heading;
+    uint16_t raw_commanded_rudder;
+    uint16_t raw_integral;
+    uint16_t raw_derivative;
+    uint16_t raw_speed_over_ground;
 
-    actual_rudder_angle_    = static_cast<float>(raw[0]) / 100.0F - 90.0F;
-    roll_                   = static_cast<float>(raw[1]) / 100.0F - 180.0F;
-    pitch_                  = static_cast<float>(raw[2]) / 100.0F - 180.0F;
-    heading_                = static_cast<float>(raw[3]) / 100.0F;
-    commanded_rudder_angle_ = static_cast<float>(raw[4]) / 100.0F - 90.0F;
-    integral_               = static_cast<int32_t>(raw[5]) - 30000;
-    derivative_             = static_cast<int32_t>(raw[6]) - 30000;
-    speed_over_ground_      = static_cast<float>(raw[7]) / 1000.0F;
+    std::memcpy(&raw_actual_rudder, cf.data + BYTE_OFF_ACTUAL_RUDDER, sizeof(uint16_t));
+    std::memcpy(&raw_roll, cf.data + BYTE_OFF_ROLL, sizeof(uint16_t));
+    std::memcpy(&raw_pitch, cf.data + BYTE_OFF_PITCH, sizeof(uint16_t));
+    std::memcpy(&raw_heading, cf.data + BYTE_OFF_HEADING, sizeof(uint16_t));
+    std::memcpy(&raw_commanded_rudder, cf.data + BYTE_OFF_COMMANDED_RUDDER, sizeof(uint16_t));
+    std::memcpy(&raw_integral, cf.data + BYTE_OFF_INTEGRAL, sizeof(uint16_t));
+    std::memcpy(&raw_derivative, cf.data + BYTE_OFF_DERIVATIVE, sizeof(uint16_t));
+    std::memcpy(
+      &raw_speed_over_ground, cf.data + BYTE_OFF_SPEED_OVER_GROUND, sizeof(uint16_t));
+
+    // These values are fixed conversions from the ELEC rudder debug CAN frame definition.
+    actual_rudder_angle_ =
+      static_cast<float>(raw_actual_rudder) / 100.0F - 90.0F;  // NOLINT(readability-magic-numbers)
+    roll_ = static_cast<float>(raw_roll) / 100.0F - 180.0F;  // NOLINT(readability-magic-numbers)
+    pitch_ = static_cast<float>(raw_pitch) / 100.0F - 180.0F;  // NOLINT(readability-magic-numbers)
+    heading_                = static_cast<float>(raw_heading) / 100.0F;
+    commanded_rudder_angle_ =
+      static_cast<float>(raw_commanded_rudder) / 100.0F -
+      90.0F;  // NOLINT(readability-magic-numbers)
+    integral_ = static_cast<int32_t>(raw_integral) - 30000;  // NOLINT(readability-magic-numbers)
+    derivative_ =
+      static_cast<int32_t>(raw_derivative) - 30000;  // NOLINT(readability-magic-numbers)
+    speed_over_ground_ =
+      static_cast<float>(raw_speed_over_ground) / 1000.0F;  // NOLINT(readability-magic-numbers)
 
     checkBounds();
 }
@@ -964,17 +986,33 @@ msg::HelperHeading RudderDebugData::toRosMsg() const
 
 CanFrame RudderDebugData::toLinuxCan() const
 {
-    std::array<uint16_t, 8> raw{
-      static_cast<uint16_t>((actual_rudder_angle_ + 90.0F) * 100.0F),
-      static_cast<uint16_t>((roll_ + 180.0F) * 100.0F),
-      static_cast<uint16_t>((pitch_ + 180.0F) * 100.0F),
-      static_cast<uint16_t>(heading_ * 100.0F),
-      static_cast<uint16_t>((commanded_rudder_angle_ + 90.0F) * 100.0F),
-      static_cast<uint16_t>(integral_ + 30000),
-      static_cast<uint16_t>(derivative_ + 30000),
-      static_cast<uint16_t>(speed_over_ground_ * 1000.0F)};
+    // These values are fixed conversions to the ELEC rudder debug CAN frame definition.
+    uint16_t raw_actual_rudder = static_cast<uint16_t>(
+      (actual_rudder_angle_ + 90.0F) * 100.0F);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_roll =
+      static_cast<uint16_t>((roll_ + 180.0F) * 100.0F);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_pitch =
+      static_cast<uint16_t>((pitch_ + 180.0F) * 100.0F);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_heading = static_cast<uint16_t>(heading_ * 100.0F);
+    uint16_t raw_commanded_rudder = static_cast<uint16_t>(
+      (commanded_rudder_angle_ + 90.0F) * 100.0F);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_integral =
+      static_cast<uint16_t>(integral_ + 30000);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_derivative =
+      static_cast<uint16_t>(derivative_ + 30000);  // NOLINT(readability-magic-numbers)
+    uint16_t raw_speed_over_ground =
+      static_cast<uint16_t>(speed_over_ground_ * 1000.0F);  // NOLINT(readability-magic-numbers)
+
     CanFrame cf = BaseFrame::toLinuxCan();
-    std::memcpy(cf.data, raw.data(), CAN_BYTE_DLEN_);
+    std::memcpy(cf.data + BYTE_OFF_ACTUAL_RUDDER, &raw_actual_rudder, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_ROLL, &raw_roll, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_PITCH, &raw_pitch, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_HEADING, &raw_heading, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_COMMANDED_RUDDER, &raw_commanded_rudder, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_INTEGRAL, &raw_integral, sizeof(uint16_t));
+    std::memcpy(cf.data + BYTE_OFF_DERIVATIVE, &raw_derivative, sizeof(uint16_t));
+    std::memcpy(
+      cf.data + BYTE_OFF_SPEED_OVER_GROUND, &raw_speed_over_ground, sizeof(uint16_t));
     return cf;
 }
 

--- a/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
@@ -937,6 +937,75 @@ void RudderData::checkBounds() const
     // DesiredHeading END
 }
 
+// RudderDebugData START
+RudderDebugData::RudderDebugData(const CanFrame & cf) : RudderDebugData(static_cast<CanId>(cf.can_id))
+{
+    std::array<uint16_t, 8> raw{};
+    std::memcpy(raw.data(), cf.data, CAN_BYTE_DLEN_);
+
+    actual_rudder_angle_    = static_cast<float>(raw[0]) / 100.0F - 90.0F;
+    roll_                   = static_cast<float>(raw[1]) / 100.0F - 180.0F;
+    pitch_                  = static_cast<float>(raw[2]) / 100.0F - 180.0F;
+    heading_                = static_cast<float>(raw[3]) / 100.0F;
+    commanded_rudder_angle_ = static_cast<float>(raw[4]) / 100.0F - 90.0F;
+    integral_               = static_cast<int32_t>(raw[5]) - 30000;
+    derivative_             = static_cast<int32_t>(raw[6]) - 30000;
+    speed_over_ground_      = static_cast<float>(raw[7]) / 1000.0F;
+
+    checkBounds();
+}
+
+msg::HelperHeading RudderDebugData::toRosMsg() const
+{
+    msg::HelperHeading msg;
+    msg.set__heading(utils::boundTo180(heading_));
+    return msg;
+}
+
+CanFrame RudderDebugData::toLinuxCan() const
+{
+    std::array<uint16_t, 8> raw{
+      static_cast<uint16_t>((actual_rudder_angle_ + 90.0F) * 100.0F),
+      static_cast<uint16_t>((roll_ + 180.0F) * 100.0F),
+      static_cast<uint16_t>((pitch_ + 180.0F) * 100.0F),
+      static_cast<uint16_t>(heading_ * 100.0F),
+      static_cast<uint16_t>((commanded_rudder_angle_ + 90.0F) * 100.0F),
+      static_cast<uint16_t>(integral_ + 30000),
+      static_cast<uint16_t>(derivative_ + 30000),
+      static_cast<uint16_t>(speed_over_ground_ * 1000.0F)};
+    CanFrame cf = BaseFrame::toLinuxCan();
+    std::memcpy(cf.data, raw.data(), CAN_BYTE_DLEN_);
+    return cf;
+}
+
+std::string RudderDebugData::debugStr() const
+{
+    std::stringstream ss;
+    ss << BaseFrame::debugStr() << "\nActual rudder: " << actual_rudder_angle_ << " Roll: " << roll_
+       << " Pitch: " << pitch_ << " Heading: " << heading_ << " Commanded rudder: "
+       << commanded_rudder_angle_ << " Integral: " << integral_ << " Derivative: " << derivative_
+       << " SOG: " << speed_over_ground_;
+    return ss.str();
+}
+
+std::string RudderDebugData::toString() const
+{
+    std::stringstream ss;
+    ss << "[RUDDER DEBUG DATA] Heading: " << heading_;
+    return ss.str();
+}
+
+RudderDebugData::RudderDebugData(CanId id)
+: BaseFrame(std::span{RUDDER_DEBUG_DATA_IDS}, id, CAN_BYTE_DLEN_)
+{
+}
+
+void RudderDebugData::checkBounds() const
+{
+    // Do not check bounds for a debug frame.
+}
+// RudderDebugData END
+
 // TempSensor START
 // TempSensor public START
 TempSensor::TempSensor(const CanFrame & cf) : TempSensor(static_cast<CanId>(cf.can_id))

--- a/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_frame_parser.cpp
@@ -959,7 +959,6 @@ RudderDebugData::RudderDebugData(const CanFrame & cf) : RudderDebugData(static_c
     std::memcpy(
       &raw_speed_over_ground, cf.data + BYTE_OFF_SPEED_OVER_GROUND, sizeof(uint16_t));
 
-    // These values are fixed conversions from the ELEC rudder debug CAN frame definition.
     actual_rudder_angle_ =
       static_cast<float>(raw_actual_rudder) / 100.0F - 90.0F;  // NOLINT(readability-magic-numbers)
     roll_ = static_cast<float>(raw_roll) / 100.0F - 180.0F;  // NOLINT(readability-magic-numbers)
@@ -986,7 +985,6 @@ msg::HelperHeading RudderDebugData::toRosMsg() const
 
 CanFrame RudderDebugData::toLinuxCan() const
 {
-    // These values are fixed conversions to the ELEC rudder debug CAN frame definition.
     uint16_t raw_actual_rudder = static_cast<uint16_t>(
       (actual_rudder_angle_ + 90.0F) * 100.0F);  // NOLINT(readability-magic-numbers)
     uint16_t raw_roll =

--- a/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver.cpp
@@ -29,7 +29,7 @@ void CanTransceiver::onNewCanData(const CanFrame & frame) const
     }
     CanId id{frame.can_id};
     if (
-      (id >= CanId::DEBUG_START && id <= CanId::DEBUG_END) ||
+      (id >= CanId::DEBUG_START && id <= CanId::DEBUG_END && id != CanId::RUDDER_DEBUG_DATA_FRAME) ||
       (id >= CanId::HEARTBEAT_START && id <= CanId::HEARTBEAT_END)) {
         return;
     }

--- a/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
@@ -21,8 +21,9 @@
 #include "mock_can_bus.h"
 #include "net_node.h"
 
-constexpr int  QUEUE_SIZE     = 10;  // Arbitrary number
-constexpr auto TIMER_INTERVAL = std::chrono::milliseconds(500);
+constexpr int  QUEUE_SIZE              = 10;  // Arbitrary number
+constexpr auto TIMER_INTERVAL          = std::chrono::milliseconds(500);
+constexpr auto RUDDER_FALLBACK_TIMEOUT = std::chrono::seconds(5);
 
 namespace msg = custom_interfaces::msg;
 using CAN_FP::CanFrame;
@@ -47,6 +48,8 @@ public:
         this->declare_parameter("can_replay_file", "");
         this->declare_parameter("can_replay_rate", 1.0);
         this->declare_parameter("can_replay_loop", false);
+        this->declare_parameter("rudder_debug", false);
+        rudder_debug_ = this->get_parameter("rudder_debug").as_bool();
 
         if (!this->get_parameter("enabled").as_bool()) {
             RCLCPP_INFO(this->get_logger(), "CAN Transceiver is DISABLED");
@@ -124,6 +127,9 @@ public:
                 std::function<void(const CanFrame &)>([this](const CanFrame & frame) { publishGPS(frame); })),
               std::make_pair(
                 CanId::RUDDER_DATA_FRAME,
+                std::function<void(const CanFrame &)>([this](const CanFrame & frame) { publishRudder(frame); })),
+              std::make_pair(
+                CanId::RUDDER_DEBUG_DATA_FRAME,
                 std::function<void(const CanFrame &)>([this](const CanFrame & frame) { publishRudder(frame); })),
               std::make_pair(CanId::SAIL_WIND, std::function<void(const CanFrame &)>([this](const CanFrame & frame) {
                                  publishWindSensor(frame);
@@ -249,6 +255,10 @@ private:
 
     // kill GPS CAN send status
     inline static bool kill_gps_can_ = false;
+
+    bool                                  rudder_debug_            = false;
+    bool                                  publishing_rudder_debug_ = false;
+    std::chrono::steady_clock::time_point last_rudder_data_ = std::chrono::steady_clock::now();
 
     /**
      * @brief Set up the mock CAN bus and transceiver for replaying a logged CAN session.
@@ -557,13 +567,38 @@ private:
     void publishRudder(const CanFrame & rudder_frame)
     {
         try {
-            CAN_FP::RudderData rudder(rudder_frame);
-            msg::HelperHeading rudder_ = rudder.toRosMsg();
-            rudder_pub_->publish(rudder_);
+            const auto id = static_cast<CanId>(rudder_frame.can_id);
+            if (id == CanId::RUDDER_DATA_FRAME) {
+                if (rudder_debug_) {
+                    return;
+                }
+
+                CAN_FP::RudderData rudder(rudder_frame);
+                msg::HelperHeading rudder_msg = rudder.toRosMsg();
+                last_rudder_data_ = std::chrono::steady_clock::now();
+                if (publishing_rudder_debug_) {
+                    RCLCPP_INFO(this->get_logger(), "Rudder data source restored to RUDDER_DATA_FRAME");
+                    publishing_rudder_debug_ = false;
+                }
+                rudder_pub_->publish(rudder_msg);
+                RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), rudder.toString().c_str());
+                return;
+            }
+
+            if (!rudder_debug_ && std::chrono::steady_clock::now() - last_rudder_data_ < RUDDER_FALLBACK_TIMEOUT) {
+                return;
+            }
+
+            CAN_FP::RudderDebugData rudder(rudder_frame);
+            msg::HelperHeading      rudder_msg = rudder.toRosMsg();
+            if (!publishing_rudder_debug_) {
+                RCLCPP_INFO(this->get_logger(), "Rudder data source switched to RUDDER_DEBUG_DATA_FRAME");
+                publishing_rudder_debug_ = true;
+            }
+            rudder_pub_->publish(rudder_msg);
             RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), rudder.toString().c_str());
-        } catch (std::out_of_range err) {
+        } catch (const std::exception & err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
-            return;
         }
     }
 

--- a/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
@@ -801,7 +801,6 @@ TEST_F(TestCanFrameParser, TestAISShipsInvalid)
     constexpr std::array<float, 2>  invalid_lons{LON_LBND - 1, LON_UBND + 1};
     constexpr std::array<float, 2>  invalid_cogs{-361, 361};
     constexpr std::array<float, 2>  invalid_sogs{SOG_SPEED_LBND - 1, SOG_SPEED_UBND + 1};
-    constexpr std::array<int8_t, 2> invalid_rots{ROT_LBND - 1, ROT_UBND + 1};
     constexpr std::array<float, 2>  invalid_widths{SHIP_DIMENSION_LBND - 2, SHIP_DIMENSION_UBND + 1};
     constexpr std::array<float, 2>  invalid_lengths{SHIP_DIMENSION_LBND - 2, SHIP_DIMENSION_UBND + 1};
 
@@ -918,38 +917,6 @@ TEST_F(TestCanFrameParser, TestAISShipsInvalid)
 
         msg::HelperROT rot;
         rot.set__rot(ROT_UBND);
-
-        msg::HelperDimension width;
-        width.set__dimension(SHIP_DIMENSION_LBND);  //NOLINT(readability-magic-numbers)
-
-        msg::HelperDimension length;
-        length.set__dimension(SHIP_DIMENSION_LBND);  //NOLINT(readability-magic-numbers)
-
-        msg.set__id(10);  //NOLINT(readability-magic-numbers)
-        msg.set__lat_lon(lat_lon);
-        msg.set__cog(cog);
-        msg.set__sog(sog);
-        msg.set__rot(rot);
-        msg.set__width(width);
-        msg.set__length(length);
-
-        EXPECT_THROW(CAN_FP::AISShips tmp(msg, valid_id), std::out_of_range);
-    };
-
-    for (int8_t invalid_rot : invalid_rots) {
-        msg::HelperLatLon lat_lon;
-        lat_lon.set__latitude(LAT_UBND);
-        lat_lon.set__longitude(LON_UBND);
-
-        msg::HelperHeading cog;
-        cog.set__heading(HEADING_LBND);
-
-        msg::HelperSpeed sog;
-        //convert to km/h
-        sog.set__speed(SOG_SPEED_UBND);
-
-        msg::HelperROT rot;
-        rot.set__rot(invalid_rot);
 
         msg::HelperDimension width;
         width.set__dimension(SHIP_DIMENSION_LBND);  //NOLINT(readability-magic-numbers)

--- a/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
+++ b/src/network_systems/projects/can_transceiver/test/test_can_transceiver.cpp
@@ -345,6 +345,47 @@ TEST_F(TestCanFrameParser, TestRudderDataInvalid)
 }
 
 /**
+ * @brief Test parsing a valid RUDDER_DEBUG_DATA_FRAME.
+ */
+TEST_F(TestCanFrameParser, RudderDebugDataTestValid)
+{
+    CAN_FP::CanFrame cf{
+      .can_id = static_cast<canid_t>(CAN_FP::CanId::RUDDER_DEBUG_DATA_FRAME),
+      .len    = CAN_FP::RudderDebugData::CAN_BYTE_DLEN_};
+    constexpr std::array<uint16_t, 8> raw{
+      10250,  // actual rudder: 12.5 degrees
+      17500,  // roll: -5 degrees
+      18250,  // pitch: 2.5 degrees
+      27125,  // heading: 271.25 degrees
+      8750,   // commanded rudder: -2.5 degrees
+      30123,  // integral: 123
+      29950,  // derivative: -50
+      12345   // speed over ground: 12.345 km/h
+    };
+    std::memcpy(cf.data, raw.data(), CAN_FP::RudderDebugData::CAN_BYTE_DLEN_);
+
+    CAN_FP::RudderDebugData rudder(cf);
+
+    EXPECT_EQ(rudder.id_, CAN_FP::CanId::RUDDER_DEBUG_DATA_FRAME);
+    EXPECT_EQ(rudder.can_byte_dlen_, CAN_FP::RudderDebugData::CAN_BYTE_DLEN_);
+    EXPECT_FLOAT_EQ(rudder.toRosMsg().heading, -88.75F);
+
+    CAN_FP::CanFrame round_trip = rudder.toLinuxCan();
+    EXPECT_EQ(round_trip.can_id, cf.can_id);
+    EXPECT_EQ(round_trip.len, cf.len);
+    EXPECT_EQ(std::memcmp(round_trip.data, cf.data, CAN_FP::RudderDebugData::CAN_BYTE_DLEN_), 0);
+}
+
+/**
+ * @brief Test an invalid ID for RUDDER_DEBUG_DATA_FRAME.
+ */
+TEST_F(TestCanFrameParser, RudderDebugDataTestInvalid)
+{
+    CAN_FP::CanFrame cf{.can_id = static_cast<canid_t>(CAN_FP::CanId::RESERVED)};
+    EXPECT_THROW(CAN_FP::RudderDebugData tmp(cf), CAN_FP::CanIdMismatchException);
+}
+
+/**
  * @brief Test ROS<->CAN Battery translations work as expected for valid input values
  *
  */


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves #1043
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
- Adds support for debug rudder data frame to CAN transceiver
- Defaults to the regular rudder data frame for heading, unless it does not receive data for 5s. Then, it will switch to debug until regular rudder data frame returns
- Can manually use the debug frame by setting launch argument `rudder_debug:=true` where it only use the debug frame for as long as the software is online
- Changes ROT bounds from [-126,126] to [-127,127]

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Tested using OWT data on mock CAN transceiver

