### PR TITLE
fix(web): reverted dynamic about page ui to static

### DIFF
--- a/src/website/views/components/About/About.tsx
+++ b/src/website/views/components/About/About.tsx
@@ -128,64 +128,91 @@ const About = () => {
 
   return (
     <div ref={rootRef}>
-      <div className={styles.container}>
-        {/* image column */}
-        <div className={styles.imageColumn}>
-          {Description.map((section, index) => (
-            <div
-              key={index}
-              ref={(image) => {
-                imageRefs.current[index] = image;
-              }}
-            >
-              <div className={styles.imageCard}>
-                <Image
-                  className={styles.image}
-                  src={section.imageSrc}
-                  width={460}
-                  height={520}
-                  alt={section.imageAlt}
-                  priority
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* progress bar */}
-        <div className={styles.progress}>
-          <div className={styles.progressFadeTop} />
-          <p ref={numberRef} className={styles.progressNumber}>
-            0{displayIndex + 1}
-          </p>
-
-          <div className={styles.progressLineWrap}>
-            {[0, 1, 2].map((dotIdx) => (
+      {/* desktop layout — hidden on mobile via CSS */}
+      <div className={styles.desktopOnly}>
+        <div className={styles.container}>
+          {/* image column */}
+          <div className={styles.imageColumn}>
+            {Description.map((section, index) => (
               <div
-                key={dotIdx}
-                ref={(el) => {
-                  dotRefs.current[dotIdx] = el;
+                key={index}
+                ref={(image) => {
+                  imageRefs.current[index] = image;
                 }}
-                className={styles.progressDot}
-                style={{ marginBottom: `${80 - 40 * dotIdx}px` }} // styling so Dot 1 is 80px from the bottom of the line, Dot 2 is 40px, & Dot 3 is 0px
-              />
+              >
+                <div className={styles.imageCard}>
+                  <Image
+                    className={styles.image}
+                    src={section.imageSrc}
+                    width={460}
+                    height={520}
+                    alt={section.imageAlt}
+                    priority
+                  />
+                </div>
+              </div>
             ))}
           </div>
-        </div>
 
-        {/* text section */}
-        <div className={styles.textColumn}>
-          <div className={styles.headingRow}>
-            <h2 className={styles.aboutTitle}>ABOUT US</h2>
-            <h3>/</h3>
-            <h3 ref={headingRef} className={styles.sectionTitle}>
-              {Description[displayIndex].title}
-            </h3>
+          {/* progress bar */}
+          <div className={styles.progress}>
+            <div className={styles.progressFadeTop} />
+            <p ref={numberRef} className={styles.progressNumber}>
+              0{displayIndex + 1}
+            </p>
+
+            <div className={styles.progressLineWrap}>
+              {[0, 1, 2].map((dotIdx) => (
+                <div
+                  key={dotIdx}
+                  ref={(el) => {
+                    dotRefs.current[dotIdx] = el;
+                  }}
+                  className={styles.progressDot}
+                  style={{ marginBottom: `${80 - 40 * dotIdx}px` }} // styling so Dot 1 is 80px from the bottom of the line, Dot 2 is 40px, & Dot 3 is 0px
+                />
+              ))}
+            </div>
           </div>
-          <p ref={textRef} className={styles.bodyText}>
-            {Description[displayIndex].content}
-          </p>
+
+          {/* text section */}
+          <div className={styles.textColumn}>
+            <div className={styles.headingRow}>
+              <h2 className={styles.aboutTitle}>ABOUT US</h2>
+              <h3>/</h3>
+              <h3 ref={headingRef} className={styles.sectionTitle}>
+                {Description[displayIndex].title}
+              </h3>
+            </div>
+            <p ref={textRef} className={styles.bodyText}>
+              {Description[displayIndex].content}
+            </p>
+          </div>
         </div>
+      </div>
+
+      {/* mobile layout — simple static sections, hidden on desktop */}
+      <div className={styles.mobileOnly}>
+        {Description.map((section, index) => (
+          <div key={index} className={styles.mobileSection}>
+            <div className={styles.headingRow}>
+              <h2 className={styles.aboutTitle}>ABOUT US</h2>
+              <h3>/</h3>
+              <h3 className={styles.sectionTitle}>{section.title}</h3>
+            </div>
+            <div className={styles.mobileImageCard}>
+              <Image
+                className={styles.image}
+                src={section.imageSrc}
+                width={460}
+                height={520}
+                alt={section.imageAlt}
+                priority={index === 0}
+              />
+            </div>
+            <p className={styles.bodyText}>{section.content}</p>
+          </div>
+        ))}
       </div>
 
       {/* dataset link */}

--- a/src/website/views/components/About/about.module.css
+++ b/src/website/views/components/About/about.module.css
@@ -135,26 +135,46 @@
   text-decoration: underline;
 }
 
+/* desktop-only wrapper: visible above 768px, hidden on mobile */
+.desktopOnly {
+  display: block;
+}
+
+/* mobile-only wrapper: hidden above 768px, visible on mobile */
+.mobileOnly {
+  display: none;
+}
+
 @media (width <= 768px) {
-  .container {
-    flex-direction: column;
-    gap: 0;
-    padding-top: 0;
-    max-width: 100%;
+  .desktopOnly {
+    display: none;
   }
 
-  /* Pinned, auto-updating text header; images scroll beneath it, keeping the
-     desktop's "text follows the active image" behaviour on one column. */
-  .textColumn {
-    order: -1;
-    position: sticky;
-    top: 52px;
-    height: auto;
-    gap: 10px;
-    padding: 16px 16px 18px;
-    background: #090909;
-    z-index: 10;
-    border-bottom: 1px solid #2a2a2a;
+  .mobileOnly {
+    display: flex;
+    flex-direction: column;
+    gap: 48px;
+    padding: 72px 16px 24px;
+  }
+
+  .mobileSection {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .mobileImageCard {
+    width: 100%;
+    overflow: hidden;
+    border-radius: 8px;
+    aspect-ratio: 460 / 520;
+  }
+
+  .mobileImageCard .image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .headingRow {
@@ -171,23 +191,5 @@
 
   .bodyText {
     font-size: 14px;
-  }
-
-  /* The vertical progress rail doesn't fit a single column. */
-  .progress {
-    display: none;
-  }
-
-  .imageColumn {
-    order: 0;
-    gap: 20px;
-    width: 100%;
-    padding: 0 8px;
-  }
-
-  .imageCard {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 460 / 520;
   }
 }


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
addresses the issue of the about page dynamic text loading breaking on mobile by making it static instead.

We originally wanted to keep it faithful to the desktop version, but that was causing a lot of issues, so we made it static instead. Should be fixed now!


### Verification
<img width="644" height="1422" alt="image" src="https://github.com/user-attachments/assets/7eda4c80-1f08-462e-afe7-a28fae460cfb" />


