### PR TITLE
Completed Test Plan Verification

### DIFF
--- a/notebooks/ethan_overnight_digest.md
+++ b/notebooks/ethan_overnight_digest.md
@@ -1,0 +1,80 @@
+
+## Run started 2026-08-16 03:26:07
+
+- log: `/workspaces/sailbot_workspace/notebooks/local_pathfinding/session_recordings/test_plans_results/2026_08_16-03_25_39_447711/overnight_dynamic_stress/launch.log`
+- interval: 900s, stall limit: 1800s, model: haiku
+
+### 2026-08-16 05:56:19
+
+- **Persistent OMPL planner failure** (every ~2 sec, starting 1786884938.852): RRTstar reports "no valid initial states" on both path-generation attempts, causing sail to be disabled repeatedly. Boat stuck at waypoint index 22 (lat 49.344, lon -123.276).
+
+### 2026-08-16 06:13:10
+
+- **Repeated planner failure** (1786885950.854–1786885979): RRTstar consistently reports "no valid initial states" across both planning attempts, failing every cycle; sails disabled as fallback. Boat stuck at waypoint index 22 (49.344°N, 123.276°W) while actual position is ~49.336°N, 123.257°W.
+
+### 2026-08-16 06:30:04
+
+**Repeated OMPL path planning failures.** RRTstar planner consistently reports "Skipping invalid start state" and "no valid initial states" (~every 4–6 seconds throughout the log: 1786886960, 1786886964, 1786886966, 1786886968, 1786886970, 1786886972, 1786886974, 1786886976, 1786886978, 1786886980, 1786886982, 1786886984, 1786886986, 1786886988). Both planning attempts fail each time, sail is disabled, and the boat holds heading 0.0 while aiming for waypoint index 22 at (49.344°N, 123.276°W). The boat is moving but path planning is broken.
+
+### 2026-08-16 06:46:56
+
+**OMPL local pathfinding systematically failing** — RRTstar consistently reports "no valid initial states" since [1786887974.85], repeating every ~2s with both planning attempts failing per cycle. Each failure disables the sail (desired_heading: 0.0, sail=False), yet the boat continues moving with GPS updates normal. This suggests the planner cannot validate the current state despite ~30s of operation.
+
+### 2026-08-16 07:03:47
+
+**Persistent RRTstar planner failure** — Every ~2 seconds from 07:03:06 onward, path planning attempts fail with "invalid start state" and "no valid initial states." Boat remains stuck at waypoint 22 (49.344°N, 123.276°W), unable to generate local paths; sail disabled repeatedly.
+
+### 2026-08-16 07:20:38
+
+- **[1786889387] navigate-2 crashed with segmentation fault (exit code -11)** — process died mid-simulation before graceful shutdown
+- **Repeated "Path intersects with collision zone" (every 2–3s throughout)** — planner repeatedly detecting path collisions, suggesting it may be cycling through similar avoidance scenarios rather than finding clear paths
+
+## 2026-08-16 07:20:38 — RUN ENDED
+
+```json
+{
+  "command": [
+    "ros2",
+    "launch",
+    "global_launch",
+    "main_launch.py",
+    "mode:=development",
+    "config:=globals.yaml",
+    "log_level:=info",
+    "test_plan:=overnight_dynamic_stress.yaml",
+    "record:=true",
+    "save_path:=notebooks/local_pathfinding/session_recordings/test_plans_results/2026_08_16-03_25_39_447711/overnight_dynamic_stress"
+  ],
+  "duration_sec": 12133.593,
+  "ended_at": "2026-08-16T07:10:20",
+  "expected_node_names": [
+    "/can_transceiver_node",
+    "/local_transceiver_node",
+    "/mock_ais",
+    "/mock_global_path",
+    "/mock_gps",
+    "/mock_wind_sensor",
+    "/navigate_main",
+    "/navigate_observer",
+    "/rosbag2_recorder",
+    "/wingsail_ctrl_node"
+  ],
+  "last_distance_m": 4217.180234218266,
+  "last_target_waypoint_index": 22,
+  "missing_node_names": [
+    "/navigate_main"
+  ],
+  "reason": "ROS nodes were missing for 10 seconds: /navigate_main",
+  "remaining_local_waypoints": 2,
+  "remaining_route_distance_m": 113466.94383448745,
+  "result_path": "/workspaces/sailbot_workspace/notebooks/local_pathfinding/session_recordings/test_plans_results/2026_08_16-03_25_39_447711/overnight_dynamic_stress/result.json",
+  "return_code": 0,
+  "ros_launch_log_path": "/workspaces/sailbot_workspace/notebooks/local_pathfinding/session_recordings/test_plans_results/2026_08_16-03_25_39_447711/overnight_dynamic_stress/launch.log",
+  "ros_launch_log_stored": true,
+  "save_path": "notebooks/local_pathfinding/session_recordings/test_plans_results/2026_08_16-03_25_39_447711/overnight_dynamic_stress",
+  "status": "FAILED",
+  "test": "overnight_dynamic_stress.yaml",
+  "test_plan_start_time": "2026-08-16T03:25:39"
+}
+```
+

--- a/src/local_pathfinding/test_plans/overnight_dynamic_stress.yaml
+++ b/src/local_pathfinding/test_plans/overnight_dynamic_stress.yaml
@@ -1,0 +1,335 @@
+# Overnight dynamic stress plan (issue #1065).
+#
+# Run with:
+#   python -m local_pathfinding.run_test_plans \
+#       -t overnight_dynamic_stress -n 1 --mode development --timeout_hours 8
+#
+# MODE: must be `development`. The events below drive mock_wind_sensor and
+# mock_gps, which only exist in development mode (see NODE_NAMES_BY_MODE in
+# run_test_plans.py). Under `sim` those two event streams are silently ignored
+# and most of this plan's difficulty disappears.
+#
+# DURATION: the route is ~120 km, roughly 12 h of sailing at 10 km/h and longer
+# still through the becalmed phases, so the run ends on TIMEOUT rather than
+# reaching the final waypoint and stopping early. Pass --timeout_hours to pick
+# the actual length; anything from 6 h up is a complete run.
+#
+# EVENT TIMELINE. Every phase that matters completes inside 6 h, so a 6 h run
+# exercises the whole plan and a longer run is a strict superset:
+#   Phase 1  0.0 h - 0.5 h   departure, dense traffic, building breeze
+#   Phase 2  0.5 h - 1.5 h   wind backs through 180 deg
+#   Phase 3  1.5 h - 3.0 h   near-calm tacking, heavy AIS list churn
+#   Phase 4  3.0 h - 4.5 h   storm: high wind, rapid shifts, converging traffic
+#   Phase 5  4.5 h - 6.0 h   global path reroute, strong drift, sustained traffic
+#   Phase 6  6.0 h - 8.0 h   bonus: second calm/storm cycle if run past 6 h
+
+tw_dir_deg: 145
+tw_speed_kmph: 18.0
+heading_deg: -51.0
+
+gps:
+  latitude: 49.280000
+  longitude: -123.180000
+  speed_kmph: 10.0
+
+# Initial departure traffic: head-on, crossing, and overtaking geometries
+# concentrated in the first few kilometres out of English Bay.
+ais:
+  - {id: 101, lat: 49.292000, lon: -123.205000, heading: 105.0, speed: 22.0, rot: 0, width: 30.0, height: 180.0}
+  - {id: 102, lat: 49.305000, lon: -123.238000, heading: -75.0, speed: 32.0, rot: 0, width: 28.0, height: 150.0}
+  - {id: 103, lat: 49.317000, lon: -123.255000, heading: -10.0, speed: 11.0, rot: 4, width: 14.0, height: 90.0}
+  - {id: 104, lat: 49.335000, lon: -123.293000, heading: 170.0, speed: 8.0, rot: -3, width: 8.0, height: 24.0}
+  - {id: 105, lat: 49.350000, lon: -123.322000, heading: 80.0, speed: 18.0, rot: 0, width: 22.0, height: 140.0}
+  - {id: 106, lat: 49.364000, lon: -123.360000, heading: 115.0, speed: 30.0, rot: 0, width: 25.0, height: 120.0}
+  - {id: 107, lat: 49.380000, lon: -123.388000, heading: -115.0, speed: 26.0, rot: 0, width: 8.0, height: 35.0}
+  - {id: 108, lat: 49.394000, lon: -123.420000, heading: 20.0, speed: 9.0, rot: 2, width: 7.0, height: 20.0}
+  - {id: 110, lat: 49.288000, lon: -123.190000, heading: -45.0, speed: 7.0, rot: 0, width: 4.0, height: 12.0}
+  - {id: 111, lat: 49.308000, lon: -123.225000, heading: -55.0, speed: 24.0, rot: 3, width: 32.0, height: 170.0}
+
+# [lon, lat]. Shoreline, islands, and shoals along the departure corridor,
+# plus two narrow gates further up the strait that the route must thread.
+land:
+  # Point Grey / Spanish Banks shoreline south of the first legs.
+  - [[-123.255000, 49.245000],
+     [-123.175000, 49.250000],
+     [-123.155000, 49.268000],
+     [-123.205000, 49.272000],
+     [-123.252000, 49.266000]]
+
+  # North Shore / West Vancouver shoreline, shifted 0.020 deg east of the
+  # original Vancouver-plan position so it flanks this NW route instead of
+  # swallowing waypoint 2. Nearest waypoint clearance ~726 m.
+  - [[-123.140000, 49.304000],
+     [-123.198000, 49.310000],
+     [-123.266000, 49.344000],
+     [-123.240000, 49.365000],
+     [-123.158000, 49.343000],
+     [-123.125000, 49.318000]]
+
+  # Inner-island obstruction on the southern side of the mid-route.
+  - [[-123.342000, 49.305000],
+     [-123.302000, 49.313000],
+     [-123.316000, 49.339000],
+     [-123.358000, 49.334000],
+     [-123.368000, 49.318000]]
+
+  # Rocky islets near the middle of the corridor.
+  - [[-123.396000, 49.322000],
+     [-123.374000, 49.327000],
+     [-123.382000, 49.344000],
+     [-123.408000, 49.338000]]
+
+  # Bowen / Howe Sound mass, shifted 0.055 deg east of the original
+  # Vancouver-plan position so it flanks this NW route instead of swallowing
+  # waypoints 4 and 5. Nearest waypoint clearance ~719 m.
+  - [[-123.287000, 49.394000],
+     [-123.337000, 49.397000],
+     [-123.383000, 49.427000],
+     [-123.350000, 49.452000],
+     [-123.287000, 49.430000],
+     [-123.260000, 49.407000]]
+
+  # Offshore shoal south-west of the later legs.
+  - [[-123.468000, 49.350000],
+     [-123.414000, 49.356000],
+     [-123.402000, 49.382000],
+     [-123.452000, 49.390000],
+     [-123.491000, 49.374000]]
+
+  # First narrow gate, around the 60 km mark.
+  - [[-123.700000, 49.560000],
+     [-123.640000, 49.566000],
+     [-123.648000, 49.598000],
+     [-123.712000, 49.592000]]
+
+  - [[-123.612000, 49.640000],
+     [-123.548000, 49.648000],
+     [-123.556000, 49.680000],
+     [-123.620000, 49.672000]]
+
+  # Second narrow gate, on the approach to the reroute destination.
+  - [[-123.960000, 49.880000],
+     [-123.900000, 49.888000],
+     [-123.908000, 49.920000],
+     [-123.972000, 49.912000]]
+
+  - [[-123.872000, 49.958000],
+     [-123.808000, 49.966000],
+     [-123.816000, 49.998000],
+     [-123.880000, 49.990000]]
+
+# Global paths in this package are stored destination-first: the first waypoint
+# is the final destination and the last waypoint is the start position.
+# 25 waypoints, ~5 km apart, ~120 km total up Georgia Strait.
+global_path:
+  waypoints:
+    - {latitude: 50.048000, longitude: -124.332000}
+    - {latitude: 50.016000, longitude: -124.284000}
+    - {latitude: 49.984000, longitude: -124.236000}
+    - {latitude: 49.952000, longitude: -124.188000}
+    - {latitude: 49.920000, longitude: -124.140000}
+    - {latitude: 49.888000, longitude: -124.092000}
+    - {latitude: 49.856000, longitude: -124.044000}
+    - {latitude: 49.824000, longitude: -123.996000}
+    - {latitude: 49.792000, longitude: -123.948000}
+    - {latitude: 49.760000, longitude: -123.900000}
+    - {latitude: 49.728000, longitude: -123.852000}
+    - {latitude: 49.696000, longitude: -123.804000}
+    - {latitude: 49.664000, longitude: -123.756000}
+    - {latitude: 49.632000, longitude: -123.708000}
+    - {latitude: 49.600000, longitude: -123.660000}
+    - {latitude: 49.568000, longitude: -123.612000}
+    - {latitude: 49.536000, longitude: -123.564000}
+    - {latitude: 49.504000, longitude: -123.516000}
+    - {latitude: 49.472000, longitude: -123.468000}
+    - {latitude: 49.440000, longitude: -123.420000}
+    - {latitude: 49.408000, longitude: -123.372000}
+    - {latitude: 49.376000, longitude: -123.324000}
+    - {latitude: 49.344000, longitude: -123.276000}
+    - {latitude: 49.312000, longitude: -123.228000}
+    - {latitude: 49.280000, longitude: -123.180000}
+
+events:
+  # ---------------------------------------------------------------- wind ----
+  # Shifts are sustained, not one-off pokes: each holds long enough for the
+  # planner to commit to a tack before the next change invalidates it.
+  mock_wind_sensor:
+    # Phase 1 (0.0-0.5 h): steady departure breeze, one moderate veer.
+    - {timestamp: 600.0, direction_deg: 160, speed_kmph: 20.0}
+    - {timestamp: 1500.0, direction_deg: 175, speed_kmph: 23.0}
+
+    # Phase 2 (0.5-1.5 h): backs through 180 deg over an hour, forcing the
+    # planner off a favoured tack it has been holding for a long stretch.
+    - {timestamp: 2100.0, direction_deg: 120, speed_kmph: 19.0}
+    - {timestamp: 3000.0, direction_deg: 55, speed_kmph: 16.0}
+    - {timestamp: 3900.0, direction_deg: -15, speed_kmph: 14.0}
+    - {timestamp: 4800.0, direction_deg: -80, speed_kmph: 12.0}
+
+    # Phase 3 (1.5-3.0 h): collapse to near-calm and hold. Exercises low-wind
+    # tacking and any divide-by-near-zero in speed-made-good calculations.
+    - {timestamp: 5700.0, direction_deg: -90, speed_kmph: 4.0}
+    - {timestamp: 6900.0, direction_deg: -95, speed_kmph: 1.5}
+    - {timestamp: 8400.0, direction_deg: 30, speed_kmph: 0.8}
+    - {timestamp: 9600.0, direction_deg: 85, speed_kmph: 2.5}
+
+    # Phase 4 (3.0-4.5 h): storm build. Large shifts at high speed, arriving
+    # faster than a full replan cycle.
+    - {timestamp: 10800.0, direction_deg: 110, speed_kmph: 28.0}
+    - {timestamp: 11700.0, direction_deg: 155, speed_kmph: 38.0}
+    - {timestamp: 12600.0, direction_deg: 95, speed_kmph: 46.0}
+    - {timestamp: 13500.0, direction_deg: 170, speed_kmph: 53.0}
+    - {timestamp: 14400.0, direction_deg: 60, speed_kmph: 48.0}
+    - {timestamp: 15300.0, direction_deg: -120, speed_kmph: 41.0}
+
+    # Phase 5 (4.5-6.0 h): easing, with a reversal right after the reroute.
+    - {timestamp: 16500.0, direction_deg: 145, speed_kmph: 32.0}
+    - {timestamp: 17700.0, direction_deg: 130, speed_kmph: 24.0}
+    - {timestamp: 19200.0, direction_deg: -40, speed_kmph: 21.0}
+    - {timestamp: 20700.0, direction_deg: 15, speed_kmph: 17.0}
+
+    # Phase 6 (6.0-8.0 h): second calm/storm cycle for runs past 6 h.
+    - {timestamp: 22200.0, direction_deg: 40, speed_kmph: 3.0}
+    - {timestamp: 23700.0, direction_deg: 45, speed_kmph: 1.0}
+    - {timestamp: 25200.0, direction_deg: 165, speed_kmph: 30.0}
+    - {timestamp: 26400.0, direction_deg: 100, speed_kmph: 49.0}
+    - {timestamp: 27600.0, direction_deg: -150, speed_kmph: 36.0}
+    - {timestamp: 28500.0, direction_deg: 150, speed_kmph: 22.0}
+
+  # ----------------------------------------------------------------- ais ----
+  # Each event replaces the entire ship list. The empty-list and shrinking-list
+  # events specifically re-stress the list-overwrite path from issue #1031:
+  # a cleared list must actually clear, not leave stale obstacles in the planner.
+  mock_ais:
+    # Phase 1: departure traffic thins to a few close targets.
+    - timestamp: 900.0
+      ships:
+        - {id: 101, lat: 49.300000, lon: -123.220000, heading: -60.0, speed: 20.0, rot: -2, width: 30.0, height: 180.0}
+        - {id: 105, lat: 49.358000, lon: -123.335000, heading: 95.0, speed: 18.0, rot: 0, width: 22.0, height: 140.0}
+        - {id: 111, lat: 49.315000, lon: -123.240000, heading: -50.0, speed: 24.0, rot: 3, width: 32.0, height: 170.0}
+
+    # Phase 2: total dropout, then a single reappearance.
+    - timestamp: 2400.0
+      ships: []
+    - timestamp: 3600.0
+      ships:
+        - {id: 201, lat: 49.430000, lon: -123.430000, heading: -160.0, speed: 14.0, rot: 0, width: 18.0, height: 95.0}
+
+    # Phase 3: rapid churn during the calm, when the boat has least steerage.
+    # Ships appear, shrink to a partial list, and vanish faster than a full replan.
+    - timestamp: 5700.0
+      ships:
+        - {id: 201, lat: 49.470000, lon: -123.470000, heading: -165.0, speed: 14.0, rot: 0, width: 18.0, height: 95.0}
+        - {id: 202, lat: 49.495000, lon: -123.505000, heading: -150.0, speed: 26.0, rot: -4, width: 26.0, height: 155.0}
+        - {id: 203, lat: 49.510000, lon: -123.480000, heading: 180.0, speed: 9.0, rot: 6, width: 9.0, height: 30.0}
+    - timestamp: 6600.0
+      ships:
+        - {id: 202, lat: 49.488000, lon: -123.498000, heading: -155.0, speed: 26.0, rot: -4, width: 26.0, height: 155.0}
+    - timestamp: 7500.0
+      ships: []
+    - timestamp: 8400.0
+      ships:
+        - {id: 204, lat: 49.540000, lon: -123.545000, heading: -170.0, speed: 31.0, rot: 0, width: 34.0, height: 195.0}
+        - {id: 205, lat: 49.552000, lon: -123.520000, heading: -135.0, speed: 12.0, rot: 8, width: 11.0, height: 42.0}
+    - timestamp: 9300.0
+      ships: []
+    - timestamp: 10200.0
+      ships:
+        - {id: 204, lat: 49.528000, lon: -123.538000, heading: -172.0, speed: 31.0, rot: 0, width: 34.0, height: 195.0}
+        - {id: 206, lat: 49.560000, lon: -123.575000, heading: -145.0, speed: 20.0, rot: -5, width: 20.0, height: 110.0}
+        - {id: 207, lat: 49.575000, lon: -123.552000, heading: -160.0, speed: 7.0, rot: 0, width: 6.0, height: 18.0}
+
+    # Phase 4: converging traffic through the storm, on near-reciprocal
+    # headings while the wind is shifting fastest.
+    - timestamp: 11400.0
+      ships:
+        - {id: 301, lat: 49.600000, lon: -123.640000, heading: -155.0, speed: 28.0, rot: 0, width: 30.0, height: 175.0}
+        - {id: 302, lat: 49.612000, lon: -123.610000, heading: -145.0, speed: 24.0, rot: -3, width: 25.0, height: 140.0}
+        - {id: 303, lat: 49.588000, lon: -123.665000, heading: -170.0, speed: 33.0, rot: 2, width: 36.0, height: 210.0}
+        - {id: 304, lat: 49.625000, lon: -123.635000, heading: -160.0, speed: 16.0, rot: 0, width: 14.0, height: 70.0}
+    - timestamp: 13200.0
+      ships:
+        - {id: 301, lat: 49.640000, lon: -123.672000, heading: -158.0, speed: 28.0, rot: 0, width: 30.0, height: 175.0}
+        - {id: 303, lat: 49.628000, lon: -123.700000, heading: -168.0, speed: 33.0, rot: 2, width: 36.0, height: 210.0}
+        - {id: 305, lat: 49.655000, lon: -123.690000, heading: -150.0, speed: 11.0, rot: -9, width: 10.0, height: 38.0}
+    - timestamp: 14700.0
+      ships:
+        - {id: 303, lat: 49.668000, lon: -123.735000, heading: -165.0, speed: 33.0, rot: 2, width: 36.0, height: 210.0}
+    - timestamp: 15900.0
+      ships: []
+
+    # Phase 5: sustained moderate traffic across the reroute.
+    - timestamp: 16800.0
+      ships:
+        - {id: 401, lat: 49.720000, lon: -123.820000, heading: -155.0, speed: 22.0, rot: 0, width: 28.0, height: 160.0}
+        - {id: 402, lat: 49.735000, lon: -123.795000, heading: -165.0, speed: 15.0, rot: 4, width: 13.0, height: 55.0}
+    - timestamp: 18600.0
+      ships:
+        - {id: 401, lat: 49.762000, lon: -123.858000, heading: -157.0, speed: 22.0, rot: 0, width: 28.0, height: 160.0}
+        - {id: 403, lat: 49.780000, lon: -123.880000, heading: -140.0, speed: 29.0, rot: -6, width: 31.0, height: 185.0}
+        - {id: 404, lat: 49.755000, lon: -123.905000, heading: -175.0, speed: 8.0, rot: 0, width: 7.0, height: 22.0}
+    - timestamp: 20400.0
+      ships:
+        - {id: 403, lat: 49.812000, lon: -123.920000, heading: -142.0, speed: 29.0, rot: -6, width: 31.0, height: 185.0}
+
+    # Phase 6: churn again for runs past 6 h, ending on an empty list so a
+    # stale-obstacle failure is obvious in the final state.
+    - timestamp: 22800.0
+      ships: []
+    - timestamp: 24000.0
+      ships:
+        - {id: 501, lat: 49.880000, lon: -123.980000, heading: -150.0, speed: 26.0, rot: 0, width: 29.0, height: 170.0}
+        - {id: 502, lat: 49.895000, lon: -123.955000, heading: -160.0, speed: 13.0, rot: 7, width: 12.0, height: 48.0}
+    - timestamp: 26100.0
+      ships:
+        - {id: 501, lat: 49.918000, lon: -124.020000, heading: -152.0, speed: 26.0, rot: 0, width: 29.0, height: 170.0}
+    - timestamp: 28200.0
+      ships: []
+
+  # ----------------------------------------------------------------- gps ----
+  # Ocean drift toggled on and off with varying magnitude and direction, so
+  # position error accumulates and then abruptly stops.
+  mock_gps:
+    - {timestamp: 1500.0, use_ocean_drift: true, ocean_drift_speed_kmph: 1.5, ocean_drift_dir_deg: -150.0}
+    - {timestamp: 3900.0, use_ocean_drift: true, ocean_drift_speed_kmph: 3.0, ocean_drift_dir_deg: 165.0}
+    - {timestamp: 5400.0, use_ocean_drift: false}
+
+    # Strong cross-track set during the calm, when steerage is lowest.
+    - {timestamp: 7200.0, use_ocean_drift: true, ocean_drift_speed_kmph: 4.5, ocean_drift_dir_deg: 95.0}
+    - {timestamp: 9600.0, use_ocean_drift: true, ocean_drift_speed_kmph: 2.0, ocean_drift_dir_deg: -80.0}
+
+    # Storm-driven set, reversing partway through.
+    - {timestamp: 11400.0, use_ocean_drift: true, ocean_drift_speed_kmph: 6.0, ocean_drift_dir_deg: 145.0}
+    - {timestamp: 14100.0, use_ocean_drift: true, ocean_drift_speed_kmph: 5.0, ocean_drift_dir_deg: -35.0}
+    - {timestamp: 15900.0, use_ocean_drift: false}
+
+    # Sustained set across the reroute.
+    - {timestamp: 17400.0, use_ocean_drift: true, ocean_drift_speed_kmph: 3.5, ocean_drift_dir_deg: 60.0}
+    - {timestamp: 20100.0, use_ocean_drift: true, ocean_drift_speed_kmph: 1.0, ocean_drift_dir_deg: -170.0}
+
+    # Phase 6 spikes.
+    - {timestamp: 22500.0, use_ocean_drift: false}
+    - {timestamp: 24600.0, use_ocean_drift: true, ocean_drift_speed_kmph: 5.5, ocean_drift_dir_deg: 120.0}
+    - {timestamp: 27000.0, use_ocean_drift: true, ocean_drift_speed_kmph: 2.5, ocean_drift_dir_deg: -70.0}
+    - {timestamp: 28500.0, use_ocean_drift: false}
+
+  # --------------------------------------------------------- global path ----
+  # Reroute at 4.5 h: destination moves north-west and the remaining waypoints
+  # change. Destination-first ordering, same as the initial path. Placed inside
+  # the 6 h window so a minimum-length run still exercises it.
+  #
+  # NOTE: run_test_plans.py parses global_path.waypoints once at startup and
+  # hands that snapshot to GoalMonitor, so the monitor keeps scoring against the
+  # ORIGINAL waypoints after this fires. Expect last_target_waypoint_index and
+  # remaining_route_distance_m in result.json to diverge from what the boat is
+  # actually following from here on. Flagged as a finding for the writeup rather
+  # than worked around, since it affects every dynamic plan that reroutes.
+  mock_global_path:
+    - timestamp: 16200.0
+      waypoints:
+        - {latitude: 50.120000, longitude: -124.010000}
+        - {latitude: 50.060000, longitude: -123.960000}
+        - {latitude: 50.000000, longitude: -123.910000}
+        - {latitude: 49.940000, longitude: -123.870000}
+        - {latitude: 49.880000, longitude: -123.840000}
+        - {latitude: 49.820000, longitude: -123.815000}
+        - {latitude: 49.760000, longitude: -123.795000}


### PR DESCRIPTION
### Description
- Added src/local_pathfinding/test_plans/overnight_dynamic_stress.yaml — 6h dynamic test plan
    - 25 waypoints, ~119 km up Georgia Strait (long enough to end on timeout, not early completion)
    - 61 timed events: 26 wind · 20 AIS · 14 GPS · 1 global-path reroute
    - Wind 0.8 → 53 km/h, shifts up to 180°, incl. becalmed and storm phases
    - 6 empty AIS lists (re-stresses the #1031 list-overwrite path)
    - 10 land polygons, tightest waypoint clearance 226 m; reroute at 4.5 h
- Run Result
    - Started 03:25:39 → ended 07:10:20, status FAILED
    - Reason: ROS nodes were missing for 10 seconds: /navigate_main
    - Reached waypoint 22 of 24; 113.5 km of 119 km remaining
    - The run did not complete — the pathfinding node crashed

- Findings
1. navigate_main segfaults
    - Died with exit code -11 (SIGSEGV), launch.log:205667
    - All other nodes exited -2 = runner's clean SIGINT after the crash
    - Native-code crash, no Python traceback
    - Followed ~78 min of sustained planner failure

2. No recovery from invalid planner start state
    - From t+2.42h: RRTstar: Skipping invalid start state → There are no valid initial states!
    - Repeated every ~2s for 78 minutes: 4,318 failures, 2,182 sail-disable events
    - Zero recovery, escalation, or state reset — boat adrift with sails down until the crash

3. Ocean drift never fed back into boat state
    - Mock GPS only
    - _drift_offset_km is cumulative (node_mock_gps.py:92,176-178), applied only to the published position (:180)
    - get_next_location() (:318-330) propagates from _current_location, which drift never touches → unbounded divergence
    - Measured to 3.10 km. At crash: actual 1,271 m clear of land, published 13 m from it — likely trigger for invalid planner start state

4. GoalMonitor can't grade reroutes
    - run_test_plans.py:96 snapshots waypoints at startup; node_goal_monitor.py:59-67 subscribes only to gps + local_path, never global_path
    - After any reroute, last_target_waypoint_index / remaining_route_distance_m are meaningless; completion can fire on the wrong destination or never
    - Fix: subscribe to global_path, reset current_waypoint_index on update

5. AIS heading validated inconsistently
    - test_plan.py:362 range-checks (-180, 180] on event ships; initial ais: block bypasses it entirely
    - vancouver_to_gulf_of_alaska_complex.yaml carries heading: 350.0, which would be rejected as an event

6. --mode sim silently drops wind + GPS events
    - mock_wind_sensor / mock_gps launch only in development
    - Under sim, all their events are discarded with no warning — would have been 40 of 61 events here 

- AI Notes found in notebooks/ethan_overnight_digest.md