### PR TITLE
Respawn subscription self-heal + launch logging cleanup

### DIFF
--- a/src/controller/controller/wingsail/wingsail_ctrl_node.py
+++ b/src/controller/controller/wingsail/wingsail_ctrl_node.py
@@ -195,6 +195,10 @@ class WingsailControllerNode(Node):
         msg.trim_tab_angle_degrees = self.__trim_tab_angle
 
         self.__trim_tab_angle_pub.publish(msg)
+        self.get_logger().debug(
+            f"Published to {self.__trim_tab_angle_pub.topic} \
+                the following angle: {msg.trim_tab_angle_degrees}"
+        )
 
     @property
     def pub_period(self) -> float:

--- a/src/controller/controller/wingsail/wingsail_ctrl_node.py
+++ b/src/controller/controller/wingsail/wingsail_ctrl_node.py
@@ -196,11 +196,6 @@ class WingsailControllerNode(Node):
 
         self.__trim_tab_angle_pub.publish(msg)
 
-        self.get_logger().info(
-            f"Published to {self.__trim_tab_angle_pub.topic} \
-                the following angle: {msg.trim_tab_angle_degrees}"
-        )
-
     @property
     def pub_period(self) -> float:
         return self.get_parameter("pub_period_sec").get_parameter_value().double_value
@@ -220,7 +215,6 @@ class WingsailControllerNode(Node):
             msg (WindSensor): Filtered wind sensor data from CanTrxRosIntf.
         """
         self.__filtered_wind_sensor = msg
-        self.get_logger().info(f"Received data from {self.__filtered_wind_sensor_sub.topic}")
 
     def __sail_sub_callback(self, msg: DesiredHeading) -> None:
         """Stores the latest desired heading data. We use the sail message to decide when the boat
@@ -229,7 +223,6 @@ class WingsailControllerNode(Node):
             msg (DesiredHeading): desired heading data from CanTrxRosIntf.
         """
         self.__sail = msg.sail
-        self.get_logger().info(f"Received data from {self.__sail_sub.topic}")
 
 
 if __name__ == "__main__":

--- a/src/local_pathfinding/local_pathfinding/local_path.py
+++ b/src/local_pathfinding/local_pathfinding/local_path.py
@@ -305,11 +305,8 @@ class LocalPath:
             bool: True if the path has expired, False otherwise.
         """
         if self.state is None:
-            self._logger.info("Path is expired, since the state is None")
             return True
         is_expired = self._now_sec() >= (self.state.path_generated_time_sec + PATH_TTL_SEC)
-        if is_expired:
-            self._logger.info("Path is expired")
         return is_expired
 
     @staticmethod
@@ -379,7 +376,6 @@ class LocalPath:
             segment = LineString([(p1.x, p1.y), (p2.x, p2.y)])
             for o in self.state.obstacles:
                 if segment.crosses(o.collision_zone) or segment.touches(o.collision_zone):
-                    self._logger.info("Path intersects with collision zone")
                     return True
         return False
 
@@ -427,13 +423,7 @@ class LocalPath:
         )
 
         if significant_change:
-            self._logger.info(
-                "Significant wind change detected: "
-                f"speed {previous_wind_data.speed_kmph:.2f} -> {current_speed_kmph:.2f} km/h "
-                f"({speed_change:.2f} km/h, threshold {speed_change_threshold:.2f} km/h); "
-                f"direction {previous_dir_deg:.2f} -> {current_dir_deg:.2f} deg "
-                f"({dir_change:.2f} deg, threshold {WIND_DIRECTION_CHANGE_THRESH_DEG:.2f} deg)"
-            )
+            pass
         else:
             self._logger.debug(
                 f"speed {previous_wind_data.speed_kmph:.2f} -> {current_speed_kmph:.2f} km/h "
@@ -507,12 +497,6 @@ class LocalPath:
         distance_to_segment_km = np.linalg.norm(rejection_vector)
 
         segment_exceeded = distance_to_segment_km > max_deviation_km
-        if segment_exceeded:
-            self._logger.info(
-                "Boat deviated from path segment: "
-                f"distance {distance_to_segment_km:.2f} km, "
-                f"max deviation {max_deviation_km:.2f} km"
-            )
 
         return segment_exceeded
 
@@ -743,12 +727,6 @@ class LocalPath:
                     + f" within {MAX_OMPL_PATH_GEN_TRIES}"
                 )
 
-            if self.state is not None:
-                time_on_prev_sec = self._now_sec() - self.state.path_generated_time_sec
-                self._logger.info(
-                    f"Previous local path was active for {time_on_prev_sec:.1f}s before switching"
-                )
-            self._logger.info(f"Updating local path: {must_change_reason.reason}")
             self.last_remaining_waypoints = self._count_remaining_waypoints()
             self.last_replan_reason = must_change_reason.reason
             # Record whether this newly accepted path was generated before the wind average
@@ -775,7 +753,6 @@ class LocalPath:
         self.last_remaining_waypoints = 0
 
         try:
-            self._logger.info(f"Reusing local path: {must_change_reason.reason}")
             heading_old_path, old_target_lp_wp_index = self.calculate_desired_heading_and_wp_index(
                 self._ompl_path.get_path(), target_lp_wp_index, boat_lat_lon  # type: ignore
             )

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_ais.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_ais.py
@@ -35,18 +35,10 @@ class MockAISNode(Node):
         )  # to avoid unused parameter warning
 
         if on_water_test:
-            self.get_logger().info(
-                "Mock AIS is running in in on-water testing. Mock AIS data will be published "
-                + "instead of real AIS data."
-            )
             self.test_plan = (
                 self.get_parameter("on_water_test_plan").get_parameter_value().string_value
             )
         else:
-            self.get_logger().info(
-                "Mock AIS is running in development mode. Mock AIS data will be published for "
-                + "testing purposes."
-            )
             self.test_plan = self.get_parameter("test_plan").get_parameter_value().string_value
 
         self.publisher_ = self.create_publisher(

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_global_path.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_global_path.py
@@ -141,7 +141,6 @@ class MockGlobalPath(Node):
                     "Node mock global path waited for 2 seconds for navigate_main, but "
                     "navigate_main didn't become alive"
                 )
-        self.get_logger().info(f"Published mock global path: {Sailbot._path_to_dict(msg)}")
         self.global_path_pub.publish(msg)
 
 

--- a/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
+++ b/src/local_pathfinding/local_pathfinding/mock_nodes/node_mock_gps.py
@@ -213,30 +213,13 @@ class MockGPS(Node):
         self.update_speed()
         self.get_next_location()
 
-        self.get_logger().info(
-            f"Actual Lat: {self._current_location.latitude:.7f} "
-            f"Actual Lon: {self._current_location.longitude:.7f}\n"
-        )
-
         if self._use_drift:
             published_location = self.add_ocean_drift(self._current_location)
-
-            self.get_logger().info(
-                f"Drift Offset: {self._drift_offset_km}\n"
-                f"Drift Speed: {self._drift_speed_kmph}\n"
-                f"Drift Direction {self._drift_dir_deg}"
-            )
         else:
             published_location = self._current_location
 
         if self._use_noise:
             published_location = self.add_gps_noise(published_location)
-
-            self.get_logger().info(
-                f"Published Lat: {published_location.latitude:.7f} "
-                f"Published Lon: {published_location.longitude:.7f} "
-                f"Noise: {self._use_noise}"
-            )
 
         msg: ci.GPS = ci.GPS(
             lat_lon=published_location,

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -33,14 +33,6 @@ NANOSEC_PER_SEC = 1_000_000_000
 MAIN_GP_FILE_PATH = "/workspaces/sailbot_workspace/src/local_pathfinding/local_pathfinding/global_path_storage/main_global_path.csv"  # noqa
 BACKUP_GP_FILE_PATH = "/workspaces/sailbot_workspace/src/local_pathfinding/local_pathfinding/global_path_storage/backup_global_path.csv"  # noqa
 
-# Respawn re-subscription self-heal (#1065): after a fast respawn a subscription can silently fail
-# to match its live publisher. The watchdog recreates our reader (best-effort, capped); it never
-# exits the node, so a legitimately quiet sensor (no AIS, GPS acquiring) is never acted on and the
-# worst case is navigate's existing sail-disabled fallback.
-SUBSCRIPTION_RESUBSCRIBE_CHECK_SEC = 2.0
-SUBSCRIPTION_RESUBSCRIBE_GRACE_SEC = 5.0
-SUBSCRIPTION_RESUBSCRIBE_MAX_ATTEMPTS = 5
-
 """
 GlobalPath intentionally stays small: it is only the waypoint list, the current waypoint index,
 whether the path came from backup storage, and whether final-destination switch-back mode is
@@ -218,34 +210,6 @@ class Sailbot(Node):
             topic="filtered_wind_sensor",
             callback=self.filtered_wind_sensor_callback,
             qos_profile=10,
-        )
-
-        # Respawn re-subscription self-heal (#1065): track/guard the continuously-published inputs.
-        # global_path is excluded (event-driven; it self-rescues from the persisted CSV).
-        self._guarded_subs = {
-            "gps": {"attr": "gps_sub", "msg_type": ci.GPS, "cb": self.gps_callback},
-            "rudder": {
-                "attr": "heading_sub",
-                "msg_type": ci.HelperHeading,
-                "cb": self.heading_callback,
-            },
-            "filtered_wind_sensor": {
-                "attr": "filtered_wind_sensor_sub",
-                "msg_type": ci.WindSensor,
-                "cb": self.filtered_wind_sensor_callback,
-            },
-            "ais_ships": {
-                "attr": "ais_ships_sub",
-                "msg_type": ci.AISShips,
-                "cb": self.ais_ships_callback,
-            },
-        }
-        self._sub_received = {topic: False for topic in self._guarded_subs}
-        self._sub_created_sec = {topic: self._now_sec() for topic in self._guarded_subs}
-        self._sub_resubscribe_attempts = {topic: 0 for topic in self._guarded_subs}
-        self._resubscribe_watchdog_timer = self.create_timer(
-            timer_period_sec=SUBSCRIPTION_RESUBSCRIBE_CHECK_SEC,
-            callback=self._resubscribe_watchdog_callback,
         )
 
         # publishers
@@ -505,7 +469,6 @@ class Sailbot(Node):
     def ais_ships_callback(self, msg: ci.AISShips) -> None:
         """Refresh the ships this message carries, leaving omitted ones to time out."""
 
-        self._sub_received["ais_ships"] = True
         self.get_logger().debug(f"Received data from {self.ais_ships_sub.topic}: {msg}")
 
         now_sec = self._now_sec()
@@ -519,7 +482,6 @@ class Sailbot(Node):
         self._rebuild_ais_snapshot()
 
     def gps_callback(self, msg: ci.GPS) -> None:
-        self._sub_received["gps"] = True
         self.get_logger().debug(f"Received data from {self.gps_sub.topic}: {msg}")
         self.gps = msg
         self.gps_timeout_start_sec = self._now_sec()
@@ -527,7 +489,6 @@ class Sailbot(Node):
     def heading_callback(self, msg: ci.HelperHeading) -> None:
         """Store a valid e-compass boat heading from the ``rudder`` topic."""
 
-        self._sub_received["rudder"] = True
         if not math.isfinite(msg.heading) or not (-180.0 < msg.heading <= 180.0):
             self.get_logger().warning(
                 f"Ignoring invalid heading from {self.heading_sub.topic}: {msg.heading}. "
@@ -576,7 +537,6 @@ class Sailbot(Node):
             self._set_gp(gp)
 
     def filtered_wind_sensor_callback(self, msg: ci.WindSensor) -> None:
-        self._sub_received["filtered_wind_sensor"] = True
         self.get_logger().debug(f"Received data from {self.filtered_wind_sensor_sub.topic}: {msg}")
         self.filtered_wind_sensor = msg
 
@@ -903,63 +863,11 @@ class Sailbot(Node):
             inactive_subs.append("filtered_wind_sensor")
         if len(inactive_subs) == 0:
             return
-        # debug, not warning: a legitimately quiet sensor (no AIS targets, GPS acquiring) makes
-        # this fire every cycle on a normal leg, so warning level would spam the launch logs.
-        self.get_logger().debug(
+        self.get_logger().warning(
             "Missing navigation inputs: "
             + ", ".join(inactive_subs)
             + "; publishing desired heading with sail disabled"
         )
-
-    def _resubscribe_watchdog_callback(self) -> None:
-        """Best-effort recovery of a subscription orphaned by a respawn (#1065).
-
-        Never exits the node: if it cannot help, navigate stays in its existing sail-disabled
-        fallback, exactly as without this. Only recreates our reader when a publisher is actually
-        discoverable; a legitimately quiet sensor (no AIS targets, GPS still acquiring) has a live
-        publisher endpoint but nothing to send, and is left alone.
-        """
-        now = self._now_sec()
-        for topic, info in self._guarded_subs.items():
-            try:
-                if self._sub_received[topic]:
-                    continue
-                if self._sub_resubscribe_attempts[topic] >= SUBSCRIPTION_RESUBSCRIBE_MAX_ATTEMPTS:
-                    continue
-                if now - self._sub_created_sec[topic] < SUBSCRIPTION_RESUBSCRIBE_GRACE_SEC:
-                    continue
-                try:
-                    publisher_present = self.count_publishers(topic) > 0
-                except Exception:  # noqa: BLE001 - graph query failed; back off and retry later
-                    self._sub_created_sec[topic] = now
-                    continue
-                if not publisher_present:
-                    # No publisher visible: either not up yet or a legitimately quiet sensor.
-                    # Never act on that; just back off.
-                    self._sub_created_sec[topic] = now
-                    continue
-                # Publisher discoverable but our reader has no data: likely a respawn orphan.
-                # Recreate our reader (new before old; a failed create leaves the old one intact).
-                old_sub = getattr(self, info["attr"])
-                new_sub = self.create_subscription(
-                    msg_type=info["msg_type"],
-                    topic=topic,
-                    callback=info["cb"],
-                    qos_profile=10,
-                )
-                setattr(self, info["attr"], new_sub)
-                try:
-                    self.destroy_subscription(old_sub)
-                except Exception:  # noqa: BLE001
-                    pass
-                self._sub_created_sec[topic] = now
-                self._sub_resubscribe_attempts[topic] += 1
-                self.get_logger().debug(
-                    f"Re-subscribed '{topic}' post-respawn "
-                    f"(attempt {self._sub_resubscribe_attempts[topic]})."
-                )
-            except Exception as err:  # noqa: BLE001 - never crash navigate
-                self.get_logger().debug(f"Re-subscribe watchdog error for '{topic}': {err}")
 
 
 if __name__ == "__main__":

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -290,7 +290,6 @@ class Sailbot(Node):
         self.received_new_global_path = False
         self._load_persisted_global_path()
         self.mode = self.get_parameter("mode").get_parameter_value().string_value
-        global_config = self.get_parameter("config").get_parameter_value().string_value
 
         # Initialize mock land obstacle
         self.land_multi_polygon = None
@@ -300,23 +299,8 @@ class Sailbot(Node):
             if self.test_plan:
                 self.get_logger().warn("User has manually overridden test plan through CLI")
 
-            self.get_logger().info("test plan: " + self.test_plan)
             test_plan = TestPlan(self.test_plan)
             self.land_multi_polygon = test_plan.land
-            self.get_logger().info("Loaded mock land data.")
-
-        if global_config == "on_water_globals.yaml":
-            self.get_logger().info(
-                f"On water globals config ({global_config}) is successfully loaded "
-            )
-        elif global_config == "launch_globals.yaml":
-            self.get_logger().info(
-                f"Launch globals config ({global_config}) is successfully loaded "
-            )
-        else:
-            self.get_logger().info(
-                f"Default globals config ({global_config}) is successfully loaded "
-            )
 
     def _now_sec(self) -> float:
         """Return the current ROS clock time in seconds."""
@@ -450,11 +434,6 @@ class Sailbot(Node):
                 return None
 
             index = self._resume_waypoint_index(path, self.gps.lat_lon)
-            path_source = "backup" if is_backup else "main"
-            self.get_logger().info(
-                f"Using persisted {path_source} global path. "
-                f"Starting at resume waypoint index: {index}"
-            )
         else:
             index = len(path.waypoints) - 1
 
@@ -493,7 +472,6 @@ class Sailbot(Node):
                     continue
 
                 self._set_gp(gp)
-                self.get_logger().info(f"Loaded global path from {file_path}")
                 return True
             except read_errors as err:
                 log = (
@@ -631,18 +609,8 @@ class Sailbot(Node):
             msg = ci.DesiredHeading()
             msg.heading.heading = desired_heading
             msg.sail = sail
-            if (
-                self.desired_heading is None
-                or desired_heading != self.desired_heading.heading.heading
-            ):
-                self.get_logger().info(f"Updating desired heading to: {msg.heading.heading:.2f}")
-
             self.desired_heading = msg
 
-            self.get_logger().info(
-                f"Publishing to {self.desired_heading_pub.topic}: {msg.heading.heading}, "
-                f"sail == {msg.sail}"  # noqa
-            )
             self.desired_heading_pub.publish(msg)
 
             self.get_logger().debug(f"Publishing local path data to {self.lpath_data_pub.topic}")
@@ -750,28 +718,20 @@ class Sailbot(Node):
         """
 
         if self.gp is None:
-            self.get_logger().info("No global path is available; disabling sail")
             self.local_path.path = ci.Path(waypoints=[])
             return 0.0, False
         if self.gps is None:
-            self.get_logger().info("No GPS is available; disabling sail")
             self.local_path.path = ci.Path(waypoints=[])
             return 0.0, False
         if self.heading is None:
-            self.get_logger().info("No rudder heading is available; disabling sail")
             self.local_path.path = ci.Path(waypoints=[])
             return 0.0, False
 
         target_global_waypoint = self.gp.target_waypoint
         if target_global_waypoint is None:
-            self.get_logger().info("Global path is exhausted; disabling sail")
             self.received_new_global_path = False
             self.local_path.path = ci.Path(waypoints=[])
             return 0.0, False
-
-        self.get_logger().info(
-            f"Current target global waypoint: {target_global_waypoint} (index: {self.gp.index})"
-        )
 
         # Check if we're close enough to the global waypoint to head to the next one
         _, _, distance_to_waypoint_m = cs.GEODESIC.inv(
@@ -787,13 +747,9 @@ class Sailbot(Node):
             received_new_global_waypoint = True
             if self.gp.switch_back_mode:
                 self.gp.do_switch_back()
-                self.get_logger().info(
-                    f"switch back mode is on; switching to index {self.gp.index}"
-                )
                 self.received_new_global_path = False
                 target_global_waypoint = self.gp.waypoints[self.gp.index]
             elif not self.gp.advance_waypoint():
-                self.get_logger().info("Reached final global waypoint; switching to index 1")
                 self.received_new_global_path = False
                 self.gp.trigger_switch_back()
                 target_global_waypoint = self.gp.waypoints[self.gp.index]
@@ -813,16 +769,6 @@ class Sailbot(Node):
                 ),
                 target_lp_wp_index=self.target_lp_wp_index,
                 received_new_global_waypoint=received_new_global_waypoint,
-            )
-
-            local_target_wp = None
-            if self.local_path.path is not None and (
-                0 <= self.target_lp_wp_index < len(self.local_path.path.waypoints)
-            ):
-                local_target_wp = self.local_path.path.waypoints[self.target_lp_wp_index]
-            self.get_logger().info(
-                f"Current target local waypoint: {local_target_wp} "
-                f"(index {self.target_lp_wp_index})"
             )
 
             self.received_new_global_path = False

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -33,6 +33,14 @@ NANOSEC_PER_SEC = 1_000_000_000
 MAIN_GP_FILE_PATH = "/workspaces/sailbot_workspace/src/local_pathfinding/local_pathfinding/global_path_storage/main_global_path.csv"  # noqa
 BACKUP_GP_FILE_PATH = "/workspaces/sailbot_workspace/src/local_pathfinding/local_pathfinding/global_path_storage/backup_global_path.csv"  # noqa
 
+# Respawn re-subscription self-heal (#1065): after a fast respawn a subscription can silently fail
+# to match its live publisher. The watchdog recreates our reader (best-effort, capped); it never
+# exits the node, so a legitimately quiet sensor (no AIS, GPS acquiring) is never acted on and the
+# worst case is navigate's existing sail-disabled fallback.
+SUBSCRIPTION_RESUBSCRIBE_CHECK_SEC = 2.0
+SUBSCRIPTION_RESUBSCRIBE_GRACE_SEC = 5.0
+SUBSCRIPTION_RESUBSCRIBE_MAX_ATTEMPTS = 5
+
 """
 GlobalPath intentionally stays small: it is only the waypoint list, the current waypoint index,
 whether the path came from backup storage, and whether final-destination switch-back mode is
@@ -210,6 +218,34 @@ class Sailbot(Node):
             topic="filtered_wind_sensor",
             callback=self.filtered_wind_sensor_callback,
             qos_profile=10,
+        )
+
+        # Respawn re-subscription self-heal (#1065): track/guard the continuously-published inputs.
+        # global_path is excluded (event-driven; it self-rescues from the persisted CSV).
+        self._guarded_subs = {
+            "gps": {"attr": "gps_sub", "msg_type": ci.GPS, "cb": self.gps_callback},
+            "rudder": {
+                "attr": "heading_sub",
+                "msg_type": ci.HelperHeading,
+                "cb": self.heading_callback,
+            },
+            "filtered_wind_sensor": {
+                "attr": "filtered_wind_sensor_sub",
+                "msg_type": ci.WindSensor,
+                "cb": self.filtered_wind_sensor_callback,
+            },
+            "ais_ships": {
+                "attr": "ais_ships_sub",
+                "msg_type": ci.AISShips,
+                "cb": self.ais_ships_callback,
+            },
+        }
+        self._sub_received = {topic: False for topic in self._guarded_subs}
+        self._sub_created_sec = {topic: self._now_sec() for topic in self._guarded_subs}
+        self._sub_resubscribe_attempts = {topic: 0 for topic in self._guarded_subs}
+        self._resubscribe_watchdog_timer = self.create_timer(
+            timer_period_sec=SUBSCRIPTION_RESUBSCRIBE_CHECK_SEC,
+            callback=self._resubscribe_watchdog_callback,
         )
 
         # publishers
@@ -477,6 +513,7 @@ class Sailbot(Node):
     def ais_ships_callback(self, msg: ci.AISShips) -> None:
         """Refresh the ships this message carries, leaving omitted ones to time out."""
 
+        self._sub_received["ais_ships"] = True
         self.get_logger().debug(f"Received data from {self.ais_ships_sub.topic}: {msg}")
 
         now_sec = self._now_sec()
@@ -490,6 +527,7 @@ class Sailbot(Node):
         self._rebuild_ais_snapshot()
 
     def gps_callback(self, msg: ci.GPS) -> None:
+        self._sub_received["gps"] = True
         self.get_logger().debug(f"Received data from {self.gps_sub.topic}: {msg}")
         self.gps = msg
         self.gps_timeout_start_sec = self._now_sec()
@@ -497,6 +535,7 @@ class Sailbot(Node):
     def heading_callback(self, msg: ci.HelperHeading) -> None:
         """Store a valid e-compass boat heading from the ``rudder`` topic."""
 
+        self._sub_received["rudder"] = True
         if not math.isfinite(msg.heading) or not (-180.0 < msg.heading <= 180.0):
             self.get_logger().warning(
                 f"Ignoring invalid heading from {self.heading_sub.topic}: {msg.heading}. "
@@ -545,6 +584,7 @@ class Sailbot(Node):
             self._set_gp(gp)
 
     def filtered_wind_sensor_callback(self, msg: ci.WindSensor) -> None:
+        self._sub_received["filtered_wind_sensor"] = True
         self.get_logger().debug(f"Received data from {self.filtered_wind_sensor_sub.topic}: {msg}")
         self.filtered_wind_sensor = msg
 
@@ -899,11 +939,63 @@ class Sailbot(Node):
             inactive_subs.append("filtered_wind_sensor")
         if len(inactive_subs) == 0:
             return
-        self.get_logger().warning(
+        # debug, not warning: a legitimately quiet sensor (no AIS targets, GPS acquiring) makes
+        # this fire every cycle on a normal leg, so warning level would spam the launch logs.
+        self.get_logger().debug(
             "Missing navigation inputs: "
             + ", ".join(inactive_subs)
             + "; publishing desired heading with sail disabled"
         )
+
+    def _resubscribe_watchdog_callback(self) -> None:
+        """Best-effort recovery of a subscription orphaned by a respawn (#1065).
+
+        Never exits the node: if it cannot help, navigate stays in its existing sail-disabled
+        fallback, exactly as without this. Only recreates our reader when a publisher is actually
+        discoverable; a legitimately quiet sensor (no AIS targets, GPS still acquiring) has a live
+        publisher endpoint but nothing to send, and is left alone.
+        """
+        now = self._now_sec()
+        for topic, info in self._guarded_subs.items():
+            try:
+                if self._sub_received[topic]:
+                    continue
+                if self._sub_resubscribe_attempts[topic] >= SUBSCRIPTION_RESUBSCRIBE_MAX_ATTEMPTS:
+                    continue
+                if now - self._sub_created_sec[topic] < SUBSCRIPTION_RESUBSCRIBE_GRACE_SEC:
+                    continue
+                try:
+                    publisher_present = self.count_publishers(topic) > 0
+                except Exception:  # noqa: BLE001 - graph query failed; back off and retry later
+                    self._sub_created_sec[topic] = now
+                    continue
+                if not publisher_present:
+                    # No publisher visible: either not up yet or a legitimately quiet sensor.
+                    # Never act on that; just back off.
+                    self._sub_created_sec[topic] = now
+                    continue
+                # Publisher discoverable but our reader has no data: likely a respawn orphan.
+                # Recreate our reader (new before old; a failed create leaves the old one intact).
+                old_sub = getattr(self, info["attr"])
+                new_sub = self.create_subscription(
+                    msg_type=info["msg_type"],
+                    topic=topic,
+                    callback=info["cb"],
+                    qos_profile=10,
+                )
+                setattr(self, info["attr"], new_sub)
+                try:
+                    self.destroy_subscription(old_sub)
+                except Exception:  # noqa: BLE001
+                    pass
+                self._sub_created_sec[topic] = now
+                self._sub_resubscribe_attempts[topic] += 1
+                self.get_logger().debug(
+                    f"Re-subscribed '{topic}' post-respawn "
+                    f"(attempt {self._sub_resubscribe_attempts[topic]})."
+                )
+            except Exception as err:  # noqa: BLE001 - never crash navigate
+                self.get_logger().debug(f"Re-subscribe watchdog error for '{topic}': {err}")
 
 
 if __name__ == "__main__":

--- a/src/local_pathfinding/local_pathfinding/node_navigate.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate.py
@@ -290,6 +290,7 @@ class Sailbot(Node):
         self.received_new_global_path = False
         self._load_persisted_global_path()
         self.mode = self.get_parameter("mode").get_parameter_value().string_value
+        global_config = self.get_parameter("config").get_parameter_value().string_value
 
         # Initialize mock land obstacle
         self.land_multi_polygon = None
@@ -301,6 +302,19 @@ class Sailbot(Node):
 
             test_plan = TestPlan(self.test_plan)
             self.land_multi_polygon = test_plan.land
+
+        if global_config == "on_water_globals.yaml":
+            self.get_logger().debug(
+                f"On water globals config ({global_config}) is successfully loaded "
+            )
+        elif global_config == "launch_globals.yaml":
+            self.get_logger().debug(
+                f"Launch globals config ({global_config}) is successfully loaded "
+            )
+        else:
+            self.get_logger().debug(
+                f"Default globals config ({global_config}) is successfully loaded "
+            )
 
     def _now_sec(self) -> float:
         """Return the current ROS clock time in seconds."""
@@ -611,6 +625,10 @@ class Sailbot(Node):
             msg.sail = sail
             self.desired_heading = msg
 
+            self.get_logger().debug(
+                f"Publishing to {self.desired_heading_pub.topic}: {msg.heading.heading}, "
+                f"sail == {msg.sail}"  # noqa
+            )
             self.desired_heading_pub.publish(msg)
 
             self.get_logger().debug(f"Publishing local path data to {self.lpath_data_pub.topic}")

--- a/src/local_pathfinding/local_pathfinding/node_navigate_observer.py
+++ b/src/local_pathfinding/local_pathfinding/node_navigate_observer.py
@@ -59,7 +59,7 @@ def ros_node(queue: Queue):
     try:
         rclpy.spin(node=sailbot_observer)
     except KeyboardInterrupt:
-        sailbot_observer.get_logger().info("Keyboard interrupt [^C], shutting down.")
+        pass
     finally:
         sailbot_observer.destroy_node()
         rclpy.shutdown()
@@ -80,7 +80,6 @@ class SailbotObserver(Node):
 
     def __init__(self, queue: Queue):
         super().__init__("navigate_observer")
-        self.get_logger().info("SailbotObserver node initialized")
 
         self.local_path_sub = self.create_subscription(
             msg_type=ci.LPathData,

--- a/src/local_pathfinding/local_pathfinding/ompl_path.py
+++ b/src/local_pathfinding/local_pathfinding/ompl_path.py
@@ -566,29 +566,9 @@ class OMPLPath:
             else:  # when OMPL uses this function, it will pass in an SE2StateInternal object
                 point = cs.XY(state.getX(), state.getY())
             if not o.is_valid(point):
-                # Per-state file logging for invalid-state. Log a write failure then re-raise
-                # TODO: remove before final launch to avoid unbounded disk growth.
-                try:
-                    log_invalid_state(state=point, obstacle=o)
-                except OSError as e:
-                    self._logger.error(f"log_invalid_state write failed: {e}")
-                    raise
                 return False
 
         return True
-
-
-def log_invalid_state(state: cs.XY, obstacle: ob.Obstacle):
-    """
-    Logs details about a state and the obstacle that makes it invalid for use in a path.
-    """
-    with open(
-        "/workspaces/sailbot_workspace/src/local_pathfinding/local_pathfinding/invalid_states.log",
-        "a",
-    ) as log_file:
-        log_file.write(
-            f"State at ({state.x:.2f},{state.y:.2f}) was invalidated by obstacle: {type(obstacle)}\n"  # noqa
-        )
 
 
 def load_pkl(file_path: str) -> Any:

--- a/src/local_pathfinding/local_pathfinding/ompl_path.py
+++ b/src/local_pathfinding/local_pathfinding/ompl_path.py
@@ -320,7 +320,6 @@ class OMPLPath:
                 # This seems like it should never happen. However, our logic updates
                 # target_lp_wp_index whenever Polaris is near the local waypoint. This update can
                 # take place before the boat has passed the said waypoint.
-                self._logger.info("Boat is behind the target_lp_wp_index")
                 projected_dist = 0.0
 
             fraction_travelled = projected_dist / total_seg_dist

--- a/src/local_pathfinding/test/test_local_path.py
+++ b/src/local_pathfinding/test/test_local_path.py
@@ -1464,7 +1464,6 @@ def test_update_if_needed_regenerates_path_when_path_must_change(
     assert local_path._ompl_path is new_ompl_path
     assert local_path.path is new_path
     assert local_path.state.global_path is inputs.global_path
-    local_path._logger.info.assert_any_call(f"Updating local path: {expected_reason}")
     ompl_path_cls.assert_called_once()
 
 
@@ -1658,7 +1657,6 @@ def test_update_if_needed_regenerates_path_for_significant_wind_change(
     assert local_path.path is new_path
     assert local_path._ompl_path is not old_ompl_path
     assert not local_path.state.wind_tracker.using_one_tw_point
-    local_path._logger.info.assert_any_call("Updating local path: Significant wind change")
     ompl_path_cls.assert_called_once()
 
 
@@ -1698,7 +1696,6 @@ def test_update_if_needed_regenerates_path_when_segment_deviation_exceeded(
     assert local_path._ompl_path is new_ompl_path
     assert local_path.path is new_path
     assert local_path._ompl_path is not old_ompl_path
-    local_path._logger.info.assert_any_call("Updating local path: Boat deviated from path segment")
     exceeded_segment_deviation.assert_called_once_with(old_path, 1, inputs.gps.lat_lon)
     ompl_path_cls.assert_called_once()
 
@@ -1733,7 +1730,6 @@ def test_update_if_needed_reuses_path_when_boat_not_deviated(
     assert local_path.path is old_path
     exceeded_segment_deviation.assert_called_once_with(old_path, 1, inputs.gps.lat_lon)
     ompl_path_cls.assert_not_called()
-    local_path._logger.info.assert_any_call("Reusing local path: Path is valid, no change needed")
 
 
 def test_update_if_needed_raises_when_path_generation_exceeds_retries():
@@ -1998,5 +1994,4 @@ def test_update_if_needed_reuses_path_when_boat_changes_heading(basic_local_path
 
     assert local_path._ompl_path is old_ompl_path
     assert local_path.path is old_path
-    local_path._logger.info.assert_any_call("Reusing local path: Path is valid, no change needed")
     ompl_path_cls.assert_not_called()

--- a/src/local_pathfinding/test/test_node_navigate.py
+++ b/src/local_pathfinding/test/test_node_navigate.py
@@ -90,6 +90,13 @@ def make_sailbot_shell(gps_lat_lon: ci.HelperLatLon | None = None) -> Sailbot:
     sailbot.heading = ci.HelperHeading(heading=45.0) if gps is not None else None
     sailbot.received_new_global_path = False
     setattr(sailbot, "_tracked_ais_ships", None)
+    # __init__ is bypassed here; seed the respawn self-heal tracking the callbacks touch (#1065).
+    sailbot._sub_received = {
+        "gps": False,
+        "rudder": False,
+        "filtered_wind_sensor": False,
+        "ais_ships": False,
+    }
     logger = FakeLogger()
     setattr(sailbot, "global_path_sub", SimpleNamespace(topic="global_path"))
     setattr(sailbot, "ais_ships_sub", SimpleNamespace(topic="ais_ships"))

--- a/src/local_pathfinding/test/test_node_navigate.py
+++ b/src/local_pathfinding/test/test_node_navigate.py
@@ -90,13 +90,6 @@ def make_sailbot_shell(gps_lat_lon: ci.HelperLatLon | None = None) -> Sailbot:
     sailbot.heading = ci.HelperHeading(heading=45.0) if gps is not None else None
     sailbot.received_new_global_path = False
     setattr(sailbot, "_tracked_ais_ships", None)
-    # __init__ is bypassed here; seed the respawn self-heal tracking the callbacks touch (#1065).
-    sailbot._sub_received = {
-        "gps": False,
-        "rudder": False,
-        "filtered_wind_sensor": False,
-        "ais_ships": False,
-    }
     logger = FakeLogger()
     setattr(sailbot, "global_path_sub", SimpleNamespace(topic="global_path"))
     setattr(sailbot, "ais_ships_sub", SimpleNamespace(topic="ais_ships"))

--- a/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
+++ b/src/network_systems/projects/can_transceiver/src/can_transceiver_ros_intf.cpp
@@ -53,7 +53,6 @@ public:
         manual_mode_  = this->get_parameter("manual_mode").as_bool();
 
         if (!this->get_parameter("enabled").as_bool()) {
-            RCLCPP_INFO(this->get_logger(), "CAN Transceiver is DISABLED");
         } else {
             this->declare_parameter("mode", rclcpp::PARAMETER_STRING);
 
@@ -65,7 +64,6 @@ public:
             CAN_REPLAY::ReplayConfig            replay_cfg;
 
             if (mode == SYSTEM_MODE::PROD) {
-                RCLCPP_INFO(this->get_logger(), "Running CAN Transceiver in production mode");
                 try {
                     can_trns_ = std::make_unique<CanTransceiver>();
                 } catch (std::runtime_error err) {
@@ -73,7 +71,6 @@ public:
                     throw err;
                 }
             } else if (mode == SYSTEM_MODE::DEV || mode == SYSTEM_MODE::SIM) {
-                RCLCPP_INFO(this->get_logger(), "Running CAN Transceiver in %s mode with CAN Sim Intf", mode.c_str());
                 try {
                     sim_intf_fd_ = mockCanFd("/tmp/CanSimIntfXXXXXX");
                     can_trns_    = std::make_unique<CanTransceiver>(sim_intf_fd_);
@@ -153,7 +150,6 @@ public:
 
             // Start replay only after callbacks are registered so the first frames of the log are not lost
             if (mock_can_bus_) {
-                RCLCPP_INFO(this->get_logger(), "Replaying %zu CAN frames", replay_frames.size());
                 mock_can_bus_->startReplay(std::move(replay_frames), replay_cfg);
             }
 
@@ -272,11 +268,9 @@ private:
      * @return parsed frames to pass to mock_can_bus_->startReplay()
      */
     std::vector<CAN_REPLAY::TimedFrame> initCanReplay(
-      const std::string & mode, const std::string & replay_file, CAN_REPLAY::ReplayConfig & cfg)
+      [[maybe_unused]] const std::string & mode, const std::string & replay_file,
+      CAN_REPLAY::ReplayConfig & cfg)
     {
-        RCLCPP_INFO(
-          this->get_logger(), "Running CAN Transceiver in %s mode replaying CAN log: %s", mode.c_str(),
-          replay_file.c_str());
         try {
             std::vector<CAN_REPLAY::TimedFrame> frames = CAN_REPLAY::CanLogReplayer::parseCsv(replay_file);
 
@@ -314,7 +308,6 @@ private:
     {
         try {
             CAN_FP::PowerOff po(po_frame);
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), "Shutting down...");
             system("$ROS_WORKSPACE/src/network_systems/scripts/shutdown.sh");  //NOLINT(concurrency-mt-unsafe)
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
@@ -412,8 +405,6 @@ private:
                 received_indices_.clear();
             }
 
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), ais_ship.toString().c_str());
-
         } catch (const std::exception & err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
         }
@@ -453,7 +444,6 @@ private:
             std::stringstream ss;
             ss << currentTime;
 
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), bat.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -476,7 +466,6 @@ private:
 
             msg::GPS gps_ = gps.toRosMsg();
             gps_pub_->publish(gps_);
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), gps.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -533,7 +522,6 @@ private:
             }
 
             publishFilteredWindSensor();
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), wind_sensor.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -560,9 +548,6 @@ private:
         filtered_wind.speed.speed = static_cast<float>(speed);
         filtered_wind.direction   = static_cast<int16_t>(direction);
         filtered_wind_sensor_pub_->publish(filtered_wind);
-        std::stringstream ss;
-        ss << "[FILTERED WIND SENSOR] Speed: " << filtered_wind.speed.speed << " Angle: " << filtered_wind.direction;
-        RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), ss.str().c_str());
     }
 
     void publishRudder(const CanFrame & rudder_frame)
@@ -578,11 +563,9 @@ private:
                 msg::HelperHeading rudder_msg = rudder.toRosMsg();
                 last_rudder_data_             = std::chrono::steady_clock::now();
                 if (publishing_rudder_debug_) {
-                    RCLCPP_INFO(this->get_logger(), "Rudder data source restored to RUDDER_DATA_FRAME");
                     publishing_rudder_debug_ = false;
                 }
                 rudder_pub_->publish(rudder_msg);
-                RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), rudder.toString().c_str());
                 return;
             }
 
@@ -593,11 +576,9 @@ private:
             CAN_FP::RudderDebugData rudder(rudder_frame);
             msg::HelperHeading      rudder_msg = rudder.toRosMsg();
             if (!publishing_rudder_debug_) {
-                RCLCPP_INFO(this->get_logger(), "Rudder data source switched to RUDDER_DEBUG_DATA_FRAME");
                 publishing_rudder_debug_ = true;
             }
             rudder_pub_->publish(rudder_msg);
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), rudder.toString().c_str());
         } catch (const std::exception & err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
         }
@@ -628,7 +609,6 @@ private:
             msg::TempSensor & temp_sensor_msg = temp_sensors_.temp_sensors[idx];
             temp_sensor_msg                   = temp_sensor.toRosMsg();
             temp_sensors_pub_->publish(temp_sensors_);
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), temp_sensor.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -654,7 +634,6 @@ private:
             msg::PhSensor & ph_sensor_msg = ph_sensors_.ph_sensors[idx];
             ph_sensor_msg                 = ph_sensor.toRosMsg();
             ph_sensors_pub_->publish(ph_sensors_);
-            RCLCPP_INFO(this->get_logger(), "%s %s", getCurrentTimeString().c_str(), ph_sensor.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -680,8 +659,6 @@ private:
             msg::SalinitySensor & salinity_sensor_msg = salinity_sensors_.salinity_sensors[idx];
             salinity_sensor_msg                       = salinity_sensor.toRosMsg();
             salinity_sensors_pub_->publish(salinity_sensors_);
-            RCLCPP_INFO(
-              this->get_logger(), "%s %s", getCurrentTimeString().c_str(), salinity_sensor.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;
@@ -702,8 +679,6 @@ private:
         try {
             auto desired_heading_frame = CAN_FP::DesiredHeading(desired_heading_, CanId::MAIN_HEADING);
             can_trns_->send(desired_heading_frame.toLinuxCan());
-            RCLCPP_INFO(
-              this->get_logger(), "%s %s", getCurrentTimeString().c_str(), desired_heading_frame.toString().c_str());
         } catch (const std::out_of_range & e) {
             RCLCPP_WARN(this->get_logger(), "%s", e.what());
             return;
@@ -723,8 +698,6 @@ private:
         sail_cmd_                = sail_cmd_input;
         auto main_trim_tab_frame = CAN_FP::MainTrimTab(sail_cmd_, CanId::MAIN_TR_TAB);
         can_trns_->send(main_trim_tab_frame.toLinuxCan());
-        RCLCPP_INFO(
-          this->get_logger(), "%s %s", getCurrentTimeString().c_str(), main_trim_tab_frame.toString().c_str());
     }
 
     // SIMULATION CALLBACKS //
@@ -754,8 +727,6 @@ private:
         try {
             CAN_FP::MainTrimTab main_trim_tab_frame(sail_cmd_input, CanId::MAIN_TR_TAB);
             can_trns_->send(main_trim_tab_frame.toLinuxCan());
-            RCLCPP_INFO(
-              this->get_logger(), "%s %s", getCurrentTimeString().c_str(), main_trim_tab_frame.toString().c_str());
         } catch (std::out_of_range err) {
             RCLCPP_WARN(this->get_logger(), "%s", err.what());
             return;


### PR DESCRIPTION
Launch prep for local pathfinding. Three separate commits on this branch:

- **Respawn re-subscribe watchdog (#1065):** after navigate auto-respawns from an
  OMPL segfault it can silently fail to re-match a live publisher and run wind-blind
  for the rest of the voyage. Adds a recovery-only watchdog that recreates an
  orphaned subscription (best-effort, capped) and never exits the node, so the worst
  case is navigate's existing sail-disabled fallback.
- **Remove invalid-state file logging:** the OMPL validity check appended to
  invalid_states.log on every invalid state (unbounded disk growth) and re-raised on
  write failure from inside the solver callback. Removed; the collision check is
  unchanged.
- **Delete INFO-level logging:** strips all INFO logs from local_pathfinding,
  controller, and network_systems (CAN and satellite transceivers) to cut disk usage
  on the boat. Warn, error, and debug are untouched.

Verification: 510/510 local_pathfinding tests pass, flake8 clean, network_systems
builds clean, and a forced-respawn sim smoke recovered navigate with no crash-loop.